### PR TITLE
Read from stdin on Windows

### DIFF
--- a/src/io.js
+++ b/src/io.js
@@ -1,5 +1,37 @@
 import fs from 'fs';
 
+function readStdin() {
+  const BUFSIZE = 256;
+  const buf = 'alloc' in Buffer ? Buffer.alloc(BUFSIZE) : new Buffer(BUFSIZE);
+  let bytesRead;
+  let out = '';
+
+  do {
+    try {
+      bytesRead = fs.readSync(process.stdin.fd, buf, 0, BUFSIZE);
+    }
+    catch (e) {
+      if (e.code === 'EAGAIN') { // 'resource temporarily unavailable'
+        // Happens on OS X 10.8.3 (not Windows 7!), if there's no
+        // stdin input - typically when invoking a script without any
+        // input (for interactive stdin input).
+        // If you were to just continue, you'd create a tight loop.
+        throw e;
+      }
+      else if (e.code === 'EOF') {
+        // Happens on Windows 7, but not OS X 10.8.3:
+        // simply signals the end of *piped* stdin input.
+        break;
+      }
+      throw e; // unexpected exception
+    }
+    // Process the chunk read.
+    out += buf.toString('utf8', 0, bytesRead);
+  } while (bytesRead !== 0); // Loop as long as stdin input is available.
+
+  return out;
+}
+
 /**
  * Input/output helpers.
  */
@@ -15,10 +47,7 @@ export default {
       return fs.readFileSync(filename).toString();
     }
     else {
-      // NOTE: This does not work in Windows.
-      // Haven't managed to figure out how to read STDIN
-      // in proper cross-platform way.
-      return fs.readFileSync('/dev/stdin').toString();
+      return readStdin();
     }
   },
 

--- a/test/binTest.js
+++ b/test/binTest.js
@@ -37,15 +37,6 @@ describe('Smoke test for the executable script', function() {
   });
 
   describe('when no input/output files given', () => {
-    beforeEach(function() {
-      // Skip this test in Windows.
-      // The reading of /dev/stdin does not work in Windows.
-      // Therefore Lebab currently does not support standard input in Windows.
-      if (os.type() === 'Windows_NT') {
-        this.skip(); // eslint-disable-line no-invalid-this
-      }
-    });
-
     it('reads STDIN and writes STDOUT', done => {
       exec('node ./bin/index.js -t let,arrow < test/test-data.js > test/output.js', (error, stdout, stderr) => {
         expect(error).to.equal(null); // eslint-disable-line no-null/no-null


### PR DESCRIPTION
Cross-platform synchronous reading from stdin.

Based on this [StackOverflow answer](https://stackoverflow.com/a/16048083/5342708).

Re-enabled stdin test on Windows.