### PR TITLE
Add support for forEach transformation

### DIFF
--- a/src/builtinTransforms.js
+++ b/src/builtinTransforms.js
@@ -14,6 +14,7 @@ import commonjsTransform from './transform/commonjs';
 import exponentTransform from './transform/exponent';
 import multiVarTransform from './transform/multiVar';
 import forOfTransform from './transform/forOf';
+import forEachTransform from './transform/forEach';
 import includesTransform from './transform/includes';
 
 const transformsMap = {
@@ -31,6 +32,7 @@ const transformsMap = {
   'exponent': exponentTransform,
   'multi-var': multiVarTransform,
   'for-of': forOfTransform,
+  'for-each': forEachTransform,
   'includes': includesTransform,
 };
 

--- a/src/transform/forEach.js
+++ b/src/transform/forEach.js
@@ -1,0 +1,155 @@
+import _ from 'lodash';
+import traverser from '../traverser';
+import isEqualAst from '../utils/isEqualAst';
+import {isReference} from '../utils/variableType';
+import {isFunction} from '../utils/functionType';
+import copyComments from '../utils/copyComments';
+import matchAliasedForLoop from '../utils/matchAliasedForLoop';
+
+export default function(ast, logger) {
+  traverser.replace(ast, {
+    enter(node) {
+      const matches = matchAliasedForLoop(node);
+
+      if (matches) {
+        let statement;
+        const {body} = matches;
+        if ((statement = returnUsed(body))) {
+          logger.warn(statement, 'Return statement used in for-loop body', 'for-each');
+          return;
+        }
+        else if ((statement = functionUsed(body))) {
+          logger.warn(statement, 'Function defined in for-loop body', 'for-each');
+          return;
+        }
+        else if ((statement = breakWithLabelUsed(body))) {
+          logger.warn(statement, 'Break statement with label used in for-loop body', 'for-each');
+          return;
+        }
+        else if ((statement = continueWithLabelUsed(body))) {
+          logger.warn(statement, 'Continue statement with label used in for-loop body', 'for-each');
+          return;
+        }
+        else if ((statement = breakUsed(body))) {
+          logger.warn(statement, 'Break statement used in for-loop body', 'for-each');
+          return;
+        }
+        else if ((statement = continueUsed(body))) {
+          logger.warn(statement, 'Continue statement used in for-loop body', 'for-each');
+          return;
+        }
+        else if (matches.indexKind !== 'let') {
+          logger.warn(node, 'Only for-loops with indexes declared as let can be tranformed (use let transform first)', 'for-each');
+          return;
+        }
+        else if (matches.itemKind !== 'const') {
+          logger.warn(node, 'Only for-loops with const array items can be tranformed (use let transform first)', 'for-each');
+          return;
+        }
+
+        return withComments(node, createForEach(matches));
+      }
+
+      if (node.type === 'ForStatement') {
+        logger.warn(node, 'Unable to transform for loop', 'for-each');
+      }
+    }
+  });
+}
+
+const loopStatements = ['ForStatement', 'ForInStatement', 'ForOfStatement', 'DoWhileStatement', 'WhileStatement'];
+
+function returnUsed(body) {
+  return statementUsedInBody(body, statement => statement.type === 'ReturnStatement', []);
+}
+
+function functionUsed(body) {
+  return statementUsedInBody(body, statement => isFunction(statement), []);
+}
+
+function breakWithLabelUsed(body) {
+  return statementUsedInBody(body, statement => statement.type === 'BreakStatement' && statement.label, []);
+}
+
+function continueWithLabelUsed(body) {
+  return statementUsedInBody(body, statement => statement.type === 'ContinueStatement' && statement.label, []);
+}
+
+
+function breakUsed(body) {
+  return statementUsedInBody(body, statement => statement.type === 'BreakStatement', [...loopStatements, 'SwitchStatement']);
+}
+
+function continueUsed(body) {
+  return statementUsedInBody(body, statement => statement.type === 'ContinueStatement', loopStatements);
+}
+
+// Find if a statement is used in the for loop body,
+// skipping certain types of nodes such as nested for loops or switch statements
+// Returns the line of the statement (if found);
+function statementUsedInBody(body, statementPredicate, skippedTypes) {
+  let statement;
+
+  traverser.traverse(body, {
+    enter(node) {
+      if (skippedTypes.indexOf(node.type) !== -1) {
+        this.skip();
+      }
+      if (statementPredicate(node)) {
+        statement = node;
+        this.break();
+      }
+    }
+  });
+
+  return statement;
+}
+
+function indexUsedInBody(newBody, index) {
+  return traverser.find(newBody, (node, parent) => {
+    return isEqualAst(node, index) && isReference(node, parent);
+  });
+}
+
+function withComments(node, forEach) {
+  copyComments({from: node, to: forEach});
+  copyComments({from: node.body.body[0], to: forEach});
+  return forEach;
+}
+
+function createForEachParams(newBody, item, index) {
+  if (indexUsedInBody(newBody, index)) {
+    return [item, index];
+  }
+  return [item];
+}
+
+function createForEach({body, item, index, array}) {
+  const newBody = removeFirstBodyElement(body);
+  const params = createForEachParams(newBody, item, index);
+  return {
+    type: 'ExpressionStatement',
+    expression: {
+      type: 'CallExpression',
+      callee: {
+        type: 'MemberExpression',
+        object: array,
+        property: {
+          type: 'Identifier',
+          name: 'forEach'
+        }
+      },
+      arguments: [{
+        type: 'ArrowFunctionExpression',
+        params,
+        body: newBody
+      }]
+    }
+  };
+}
+
+function removeFirstBodyElement(body) {
+  return Object.assign({}, body, {
+    body: _.tail(body.body)
+  });
+}

--- a/src/transform/forOf.js
+++ b/src/transform/forOf.js
@@ -1,9 +1,9 @@
 import _ from 'lodash';
-import traverser from '../../traverser';
-import isEqualAst from '../../utils/isEqualAst';
-import {isReference} from '../../utils/variableType';
-import copyComments from '../../utils/copyComments';
-import matchAliasedForLoop from './matchAliasedForLoop';
+import traverser from '../traverser';
+import isEqualAst from '../utils/isEqualAst';
+import {isReference} from '../utils/variableType';
+import copyComments from '../utils/copyComments';
+import matchAliasedForLoop from '../utils/matchAliasedForLoop';
 
 export default function(ast, logger) {
   traverser.replace(ast, {

--- a/src/utils/matchAliasedForLoop.js
+++ b/src/utils/matchAliasedForLoop.js
@@ -1,5 +1,5 @@
-import isEqualAst from '../../utils/isEqualAst';
-import {matchesAst, extract, matchesLength} from '../../utils/matchesAst';
+import isEqualAst from './isEqualAst';
+import {matchesAst, extract, matchesLength} from './matchesAst';
 
 // Matches <ident>++ or ++<ident>
 const matchPlusPlus = matchesAst({

--- a/src/utils/transformForLoop.js
+++ b/src/utils/transformForLoop.js
@@ -1,0 +1,52 @@
+import _ from 'lodash';
+import traverser from '../traverser';
+import copyComments from '../utils/copyComments';
+import {matchesAst} from '../utils/matchesAst';
+
+export function withComments(node, forEach) {
+  copyComments({from: node, to: forEach});
+  copyComments({from: node.body.body[0], to: forEach});
+  return forEach;
+}
+
+export function transformForLoopBodyElement({body, item, index, array}) {
+  return replaceArrayItemInBodyElement({
+    body: removeFirstBodyElement(body),
+    item,
+    index,
+    array
+  });
+}
+
+export function removeFirstBodyElement(body) {
+  return Object.assign({}, body, {
+    body: _.tail(body.body)
+  });
+}
+
+function replaceArrayItemInBodyElement({body, item, index, array}) {
+  traverser.replace(body, {
+    enter(node) {
+      const matches = matchesItem(index, array)(node);
+      if (matches) {
+        return item;
+      }
+    }
+  });
+
+  return body;
+}
+
+function matchesItem(index, array) {
+  return matchesAst({
+    type: 'MemberExpression',
+    object: {
+      type: 'Identifier',
+      name: array.name
+    },
+    property: {
+      type: 'Identifier',
+      name: index.name
+    }
+  });
+}

--- a/test/transform/forEachTest.js
+++ b/test/transform/forEachTest.js
@@ -1,0 +1,409 @@
+import createTestHelpers from '../createTestHelpers';
+const {expectTransform, expectNoChange} = createTestHelpers(['for-each']);
+
+describe('For loops to for-each', () => {
+  describe('with existing array element alias', () => {
+    it('should use the existing alias as loop variable', () => {
+      expectTransform(
+        'for (let i=0; i < array.length; i++) {\n' +
+        '  const item = array[i];\n' +
+        '  console.log(item);\n' +
+        '}'
+      ).toReturn(
+        'array.forEach(item => {\n' +
+        '  console.log(item);\n' +
+        '});'
+      );
+    });
+
+    it('should work with different variables and long for-loop body', () => {
+      expectTransform(
+        'for (let idx=0; idx < fruitList.length; idx++) {\n' +
+        '  const fruit = fruitList[idx];\n' +
+        '  const price = getCurrentPrice(fruit);\n' +
+        '  if (price > fruit.standardPrice) {\n' +
+        '    sell(fruit, price);\n' +
+        '  }\n' +
+        '}'
+      ).toReturn(
+        'fruitList.forEach(fruit => {\n' +
+        '  const price = getCurrentPrice(fruit);\n' +
+        '  if (price > fruit.standardPrice) {\n' +
+        '    sell(fruit, price);\n' +
+        '  }\n' +
+        '});'
+      );
+    });
+
+    it('should support complex expressions for array', () => {
+      expectTransform(
+        'for (let i=0; i < store[current].fruits.length; i++) {\n' +
+        '  const item = store[current].fruits[i];\n' +
+        '  console.log(item);\n' +
+        '}'
+      ).toReturn(
+        'store[current].fruits.forEach(item => {\n' +
+        '  console.log(item);\n' +
+        '});'
+      );
+    });
+
+    it('should transform ++i loop-increment', () => {
+      expectTransform(
+        'for (let i=0; i < array.length; ++i) {\n' +
+        '  const item = array[i];\n' +
+        '  console.log(item);\n' +
+        '}'
+      ).toReturn(
+        'array.forEach(item => {\n' +
+        '  console.log(item);\n' +
+        '});'
+      );
+    });
+
+    it('should transform i+=1 loop-increment', () => {
+      expectTransform(
+        'for (let i=0; i < array.length; i+=1) {\n' +
+        '  const item = array[i];\n' +
+        '  console.log(item);\n' +
+        '}'
+      ).toReturn(
+        'array.forEach(item => {\n' +
+        '  console.log(item);\n' +
+        '});'
+      );
+    });
+
+    it('should transform when index identifier used as object literal key', () => {
+      expectTransform(
+        'for (let i=0; i < array.length; i++) {\n' +
+        '  const item = array[i];\n' +
+        '  console.log(item, {i: 123});\n' +
+        '}'
+      ).toReturn(
+        'array.forEach(item => {\n' +
+        '  console.log(item, {i: 123});\n' +
+        '});'
+      );
+    });
+
+    it('should transform when index identifier used as object property', () => {
+      expectTransform(
+        'for (let i=0; i < array.length; i++) {\n' +
+        '  const item = array[i];\n' +
+        '  console.log(item.i);\n' +
+        '}'
+      ).toReturn(
+        'array.forEach(item => {\n' +
+        '  console.log(item.i);\n' +
+        '});'
+      );
+    });
+
+    it('should transform when an array is used in the loop body', () => {
+      expectTransform(
+        'for (let i=0; i < array.length; i++) {\n' +
+        '  const item = array[i];\n' +
+        '  console.log(array);\n' +
+        '}'
+      ).toReturn(
+        'array.forEach(item => {\n' +
+        '  console.log(array);\n' +
+        '});'
+      );
+    });
+
+    it('should transform when index identifier used in loop body', () => {
+      expectTransform(
+        'for (let i=0; i < array.length; i++) {\n' +
+        '  const item = array[i];\n' +
+        '  console.log(item, i);\n' +
+        '}'
+      ).toReturn(
+        'array.forEach((item, i) => {\n' +
+        '  console.log(item, i);\n' +
+        '});'
+      );
+    });
+
+    describe('should transform when loop contains a break inside another', () => {
+      it('switch statement', () => {
+        expectTransform(
+          'for (let i=0; i < xs.length; i++) {\n' +
+          '  const x = xs[i];\n' +
+          '  switch (x % 2) {\n' +
+          '    case 0:\n' +
+          '      console.log("even");\n' +
+          '      break;\n' +
+          '    default:\n' +
+          '      console.log("odd");\n' +
+          '  }\n' +
+          '}'
+        ).toReturn(
+          'xs.forEach(x => {\n' +
+          '  switch (x % 2) {\n' +
+          '    case 0:\n' +
+          '      console.log("even");\n' +
+          '      break;\n' +
+          '    default:\n' +
+          '      console.log("odd");\n' +
+          '  }\n' +
+          '});'
+        );
+      });
+
+      it('for loop', () => {
+        expectTransform(
+          'for (let i = 0; i < array.length; i++) {\n' +
+          '  const x = array[i];\n' +
+          '  console.log(x);\n' +
+          '  for (let j = 0; j < x.length; j++) {\n' +
+          '    const y = x[j];\n' +
+          '    console.log(y);\n' +
+          '    if (item == 2) {\n' +
+          '      break;\n' +
+          '    }\n' +
+          '  }\n' +
+          '}'
+        ).toReturn(
+          'array.forEach(x => {\n' +
+          '  console.log(x);\n' +
+          '  for (let j = 0; j < x.length; j++) {\n' +
+          '    const y = x[j];\n' +
+          '    console.log(y);\n' +
+          '    if (item == 2) {\n' +
+          '      break;\n' +
+          '    }\n' +
+          '  }\n' +
+          '});'
+        );
+      });
+    });
+
+    describe('should not transform', () => {
+      it('when loop body contains a return statement', () => {
+        expectNoChange(
+          'function foo() {\n' +
+          '  for (let i=0; i < array.length; i++) {\n' +
+          '    const item = array[i];\n' +
+          '    if (item == 2) {\n' +
+          '      return;\n' +
+          '    }\n' +
+          '  }\n' +
+          '}'
+        ).withWarnings([
+          {line: 5, msg: 'Return statement used in for-loop body', type: 'for-each'}
+        ]);
+      });
+
+      it('when loop body contains a function declaration', () => {
+        expectNoChange(
+          'for (let i=0; i < array.length; i++) {\n' +
+          '  const item = array[i];\n' +
+          '  f = function() {\n' +
+          '  console.log(item)\n' +
+          '  }\n' +
+          '}'
+        ).withWarnings([
+          {line: 3, msg: 'Function defined in for-loop body', type: 'for-each'}
+        ]);
+      });
+
+
+      it('when loop body contains a break statement', () => {
+        expectNoChange(
+          'for (let i=0; i < array.length; i++) {\n' +
+          '  const item = array[i];\n' +
+          '  if (item == 2) {\n' +
+          '    break;\n' +
+          '  }\n' +
+          '}'
+        ).withWarnings([
+          {line: 4, msg: 'Break statement used in for-loop body', type: 'for-each'}
+        ]);
+      });
+
+      it('when loop body contains a continue statement', () => {
+        expectNoChange(
+          'for (let i=0; i < array.length; i++) {\n' +
+          '  const item = array[i];\n' +
+          '  continue;\n' +
+          '}'
+        ).withWarnings([
+          {line: 3, msg: 'Continue statement used in for-loop body', type: 'for-each'}
+        ]);
+      });
+
+      it('when loop body contains a break statement with label', () => {
+        expectNoChange(
+          'loop1:\n' +
+          'for (let i = 0; i < xs.length; i++) {\n' +
+          '  const x = xs[i];\n' +
+          '  loop2:\n' +
+          '  for (let j = 0; j < ys.length; j++) {\n' +
+          '    const y = ys[i];\n' +
+          '    if (i === 1 && j === 1) {\n' +
+          '      break loop1;\n' +
+          '    }\n' +
+          '    console.log("i = " + i + ", j = " + j);\n' +
+          '  }\n' +
+          '}'
+        ).withWarnings([
+          {line: 8, msg: 'Break statement with label used in for-loop body', type: 'for-each'},
+          {line: 5, msg: 'Unable to transform for loop', type: 'for-each'},
+        ]);
+      });
+
+      it('when loop body contains a continue statement with label', () => {
+        expectNoChange(
+          'loop1:\n' +
+          'for (let i = 0; i < xs.length; i++) {\n' +
+          '  const x = xs[i];\n' +
+          '  loop2:\n' +
+          '  for (let j = 0; j < ys.length; j++) {\n' +
+          '    const y = ys[i];\n' +
+          '    if (i === 1 && j === 1) {\n' +
+          '      continue loop1;\n' +
+          '    }\n' +
+          '    console.log("i = " + i + ", j = " + j);\n' +
+          '  }\n' +
+          '}'
+        ).withWarnings([
+          {line: 8, msg: 'Continue statement with label used in for-loop body', type: 'for-each'},
+          {line: 5, msg: 'Unable to transform for loop', type: 'for-each'},
+        ]);
+      });
+
+      it('when loop index variable defined with var', () => {
+        expectNoChange(
+          'for (var i=0; i < array.length; i++) {\n' +
+          '  const item = array[i];\n' +
+          '  console.log(item);\n' +
+          '}'
+        ).withWarnings([
+          {line: 1, msg: 'Only for-loops with indexes declared as let can be tranformed (use let transform first)', type: 'for-each'}
+        ]);
+      });
+
+      it('when loop array item variable defined with var', () => {
+        expectNoChange(
+          'for (let i=0; i < array.length; i++) {\n' +
+          '  var item = array[i];\n' +
+          '  console.log(item);\n' +
+          '}'
+        ).withWarnings([
+          {line: 1, msg: 'Only for-loops with const array items can be tranformed (use let transform first)', type: 'for-each'}
+        ]);
+      });
+
+      it('when loop array item variable defined with let', () => {
+        expectNoChange(
+          'for (let i=0; i < array.length; i++) {\n' +
+          '  let item = array[i];\n' +
+          '  console.log(item);\n' +
+          '}'
+        ).withWarnings([
+          {line: 1, msg: 'Only for-loops with const array items can be tranformed (use let transform first)', type: 'for-each'}
+        ]);
+      });
+
+      it('when loop initializes several variables', () => {
+        expectNoChange(
+          'for (let i=0, j=0; i < array.length; i++) {\n' +
+          '  const item = array[i];\n' +
+          '  console.log(item);\n' +
+          '}'
+        ).withWarnings([
+          {line: 1, msg: 'Unable to transform for loop', type: 'for-each'}
+        ]);
+      });
+
+      it('when loop runs backwards', () => {
+        expectNoChange(
+          'for (let i = array.length-1; i >= 0; i--) {\n' +
+          '  const item = array[i];\n' +
+          '  console.log(item);\n' +
+          '}'
+        ).withWarnings([
+          {line: 1, msg: 'Unable to transform for loop', type: 'for-each'}
+        ]);
+      });
+
+      it('when elements taken from different array', () => {
+        expectNoChange(
+          'for (let i=0; i < array.length; i++) {\n' +
+          '  const item = otherArray[i];\n' +
+          '  console.log(item);\n' +
+          '}'
+        ).withWarnings([
+          {line: 1, msg: 'Unable to transform for loop', type: 'for-each'}
+        ]);
+      });
+
+      it('when elements taken from different index', () => {
+        expectNoChange(
+          'for (let i=0; i < array.length; i++) {\n' +
+          '  const item = array[otherIndex];\n' +
+          '  console.log(item);\n' +
+          '}'
+        ).withWarnings([
+          {line: 1, msg: 'Unable to transform for loop', type: 'for-each'}
+        ]);
+      });
+
+      it('when incrementing a different index', () => {
+        expectNoChange(
+          'for (let i=0; i < array.length; otherIndex++) {\n' +
+          '  const item = array[i];\n' +
+          '  console.log(item);\n' +
+          '}'
+        ).withWarnings([
+          {line: 1, msg: 'Unable to transform for loop', type: 'for-each'}
+        ]);
+      });
+
+      it('when comparing a different index', () => {
+        expectNoChange(
+          'for (let i=0; otherIndex < array.length; i++) {\n' +
+          '  const item = array[i];\n' +
+          '  console.log(item);\n' +
+          '}'
+        ).withWarnings([
+          {line: 1, msg: 'Unable to transform for loop', type: 'for-each'}
+        ]);
+      });
+    });
+
+    describe('comments', () => {
+      it('should preserve for-loop comments', () => {
+        expectTransform(
+          '// Some comments\n' +
+          'for (let i=0; i < array.length; i++) {\n' +
+          '  const item = array[i];\n' +
+          '  console.log(item.i);\n' +
+          '}'
+        ).toReturn(
+          '// Some comments\n' +
+          'array.forEach(item => {\n' +
+          '  console.log(item.i);\n' +
+          '});'
+        );
+      });
+
+      it('should preserve loop variable comments', () => {
+        expectTransform(
+          'for (let i=0; i < array.length; i++) {\n' +
+          '  // Some comments\n' +
+          '  const item = array[i];\n' +
+          '  console.log(item.i);\n' +
+          '}'
+        ).toReturn(
+          '// Some comments\n' +
+          'array.forEach(item => {\n' +
+          '  console.log(item.i);\n' +
+          '});'
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds support for transforming simple for loops into `forEach` loops #188.

This builds on the code for transforming for loops into `for-each` loops and refactors the code to share as much as possible.

This code adds the index and array as required.

To simplifiy the transformation of old code by allowing the author to name the loop variable at the start of the code and then lebab will do this rewriting in the rest of the loop.

So, taking the example from #169.

```js
for (let i = 0; i < fruits.length; i++) {
   let fruitItem = fruits[i];
   console.log(fruits[i]);
}
// -->
fruits.forEach(fruitItem => {
   console.log(fruitItem);
});
```

or a more complicated example

```js
for (let i = 0; i < xs.length; i++) {
  const x = xs[i];
  console.log(xs[i]);
  for (let j = 0; j < xs[i].length; j++) {
    const y = xs[i][j];
    console.log(xs[i][j]);
  }
}
// -->
xs.forEach(x => {
  console.log(x);
  x.forEach(y => {
    console.log(y);
  });
});
```