### PR TITLE
Use the correct upper scope

### DIFF
--- a/src/withScope.js
+++ b/src/withScope.js
@@ -30,7 +30,7 @@ export default function withScope(ast, {enter = emptyFn, leave = emptyFn}) {
     },
     leave(node, parent) {
       if (isFunction(node)) {
-        currentScope = scopeManager.upper;
+        currentScope = currentScope.upper;
       }
       return leave.call(this, node, parent, currentScope);
     }


### PR DESCRIPTION
I'm not sure what bugs this is causing, but it definitely looks broken. There is no such thing as `scopeManager.upper`. Following the [docs](https://github.com/estools/escope/blob/aa35861faa76a09f01203dee3497a939d70b463c/README.md#example), I changed it to `currentScope.upper`.