### PR TITLE
Fix typo for 'No transforms specifed'

### DIFF
--- a/src/parseOptions.js
+++ b/src/parseOptions.js
@@ -85,7 +85,7 @@ function getReplace() {
 
 function getTransforms() {
   if (!program.transform || program.transform.length === 0) {
-    throw `No transforms specifed :(
+    throw `No transforms specified :(
 
 Use --transform option to pick one of the following:
 ${transformsDocs}`;

--- a/test/parseOptionsTest.js
+++ b/test/parseOptionsTest.js
@@ -18,7 +18,7 @@ describe('Command Line Interface', () => {
   it('when no transforms given, throws error', () => {
     expect(() => {
       parse([]);
-    }).to.throw('No transforms specifed :(');
+    }).to.throw('No transforms specified :(');
   });
 
   it('when single transforms given, enables it', () => {


### PR DESCRIPTION
Sorry for the small change, but this bugged my for some time. Thanks guys, great work!