### PR TITLE
Adds auto original

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.log
 node_modules
 lib
+.vscode

--- a/src/Cli.js
+++ b/src/Cli.js
@@ -1,8 +1,10 @@
 import glob from 'glob';
+import path from 'path';
 import parseOptions from './parseOptions';
 import builtinTransforms from './builtinTransforms';
 import io from './io';
 
+const originalPrefix = '_original.';
 /**
  * Lebab command line app
  */
@@ -19,14 +21,51 @@ export default class Cli {
       process.exit(2);
     }
 
-    this.transformer = builtinTransforms.createTransformer(this.options.transforms);
+    if (this.options.transforms) {
+      this.transformer = builtinTransforms.createTransformer(this.options.transforms);
+    }
   }
 
   /**
    * Runs the app
    */
   run() {
-    if (this.options.replace) {
+    if (this.options.deleteOriginals) {
+      const deletePath = path.join(this.options.deleteOriginals, `${originalPrefix}*`);
+      // I couldn't get glob.sync to ignore node_modules.
+      glob(deletePath, {
+        ignore: ['**/node_modules/**'],
+        nodir: true,
+        nosort: true
+      }, (err, files) => {
+        if (err) {
+          console.log('globe error', err); // eslint-disable-line no-console
+        }
+        files.forEach((file) => {
+          console.log(`Deleting ${file}`); // eslint-disable-line no-console
+          io.unlink(file);
+        });
+      });
+    }
+    else if (this.options.replaceSaveOriginal) {
+      // I couldn't get glob.sync to ignore node_modules.
+      glob(this.options.replaceSaveOriginal, {
+        ignore: ['**/node_modules/**', `**/${originalPrefix}*`],
+        nodir: true,
+        nosort: true
+      }, (err, files) => {
+        if (err) {
+          console.log('globe error', err); // eslint-disable-line no-console
+        }
+        files.forEach((file) => {
+          if (file.indexOf('/node_modules/') >= 0 || file.indexOf(originalPrefix) >= 0) {
+            return;
+          }
+          this.transformFile(file, file);
+        });
+      });
+    }
+    else if (this.options.replace) {
       // Transform all files in a directory
       glob.sync(this.options.replace).forEach((file) => {
         this.transformFile(file, file);
@@ -38,20 +77,46 @@ export default class Cli {
     }
   }
 
-  transformFile(inFile, outFile) {
-    const {code, warnings} = this.transformer.run(io.read(inFile));
-
-    // Log warnings if there are any
-    if (warnings.length > 0 && inFile) {
-      console.error(`${inFile}:`); // eslint-disable-line no-console
+  prefixFileName(fullPath, prefix) {
+    const parts = path.parse(fullPath);
+    let dir = parts.dir;
+    if (dir) {
+      dir = `${dir}/`;
     }
+    const name = `${prefix}${parts.name}`;
+    const newFileName = `${dir}${name}${parts.ext}`;
+    return newFileName;
+  }
 
-    warnings.forEach(({line, msg, type}) => {
-      console.error(  // eslint-disable-line no-console
-        `${line}:  warning  ${msg}  (${type})`
-      );
-    });
+  transformFile(inFile, outFile) {
+    try {
+      const inFileText = io.read(inFile);
+      const {code, warnings} = this.transformer.run(inFileText);
 
-    io.write(outFile, code);
+      // Log warnings if there are any
+      if (warnings.length > 0 && inFile) {
+        console.error(`${inFile}:`); // eslint-disable-line no-console
+      }
+
+      warnings.forEach(({line, msg, type}) => {
+        console.error( // eslint-disable-line no-console
+          `${inFile} ${line}:  warning  ${msg}  (${type})`
+        );
+      });
+
+      // only write if something changed.  speed improvement
+      if (inFileText !== outFile) {
+        if (this.options.replaceSaveOriginal) {
+          const originalInFile = this.prefixFileName(inFile, originalPrefix);
+          io.write(originalInFile, inFileText);
+          console.log(`${inFile} copied to ${originalInFile} and tranformed to ES6 in ${outFile}`); // eslint-disable-line no-console
+        }
+        io.write(outFile, code);
+      }
+    }
+    catch (error) {
+      // gracefully handle parse errors
+      console.error(`Error in ${inFile} line:${error.lineNumber}:${error.column} message: ${error.message}`); // eslint-disable-line no-console
+    }
   }
 }

--- a/src/io.js
+++ b/src/io.js
@@ -65,5 +65,16 @@ export default {
     else {
       process.stdout.write(data);
     }
-  }
+  },
+
+  /**
+   * Deletes a file.
+   * When no filename given, no operation occurs.
+   * @param  {String} filename
+   */
+  unlink(filename) {
+    if (filename) {
+      fs.unlinkSync(filename);
+    }
+  },
 };

--- a/src/parseOptions.js
+++ b/src/parseOptions.js
@@ -36,6 +36,11 @@ program.option('-o, --out-file <file>', 'write output to a file');
 program.option('--replace <dir>', `in-place transform all *.js files in a directory
                          <dir> can also be a single file or a glob pattern`);
 program.option('-t, --transform <a,b,c>', 'one or more transformations to perform', v => v.split(','));
+program.option('-s, --replaceSaveOriginal <dir>', `in-place transform all *.js files in a directory
+                         <dir> can also be a single file or a glob pattern
+                         makes a copy of each file for comparison prefixed with _original
+                         automatically skips node_modules`);
+program.option('-d, --deleteOriginals <dir>', `removes all files prefixed with _original`);
 
 /**
  * Parses and validates command line options from argv.
@@ -52,6 +57,8 @@ export default function parseCommandLineOptions(argv) {
     inFile: getInputFile(),
     outFile: program.outFile,
     replace: getReplace(),
+    replaceSaveOriginal: getReplaceSaveOriginal(),
+    deleteOriginals: getDeleteOriginals(),
     transforms: getTransforms(),
   };
 }
@@ -83,7 +90,46 @@ function getReplace() {
   return program.replace;
 }
 
+function getReplaceSaveOriginal() {
+  if (!program.replaceSaveOriginal) {
+    return undefined;
+  }
+  if (program.outFile) {
+    throw 'The --replaceSaveOriginal and --out-file options cannot be used together.';
+  }
+  if (program.args[0]) {
+    throw 'The --replaceSaveOriginal and plain input file options cannot be used together.\n' +
+      'Did you forget to quote the --replaceSaveOriginal parameter?';
+  }
+  if (fs.existsSync(program.replaceSaveOriginal) && fs.statSync(program.replaceSaveOriginal).isDirectory()) {
+    return path.join(program.replaceSaveOriginal, '/**/*.js');
+  }
+  return program.replaceSaveOriginal;
+}
+
+function getDeleteOriginals() {
+  if (!program.deleteOriginals) {
+    return undefined;
+  }
+  if (program.outFile) {
+    throw 'The --deleteOriginals and --out-file options cannot be used together.';
+  }
+  if (program.args[0]) {
+    throw 'The --deleteOriginals and plain input file options cannot be used together.\n' +
+      'Did you forget to quote the --deleteOriginals parameter?';
+  }
+  const dir = path.resolve(program.deleteOriginals).replace('**', '');
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    throw 'The --deleteOriginals options must be used on a directory.';
+  }
+  return program.deleteOriginals;
+}
+
+
 function getTransforms() {
+  if (program.deleteOriginals) {
+    return;
+  }
   if (!program.transform || program.transform.length === 0) {
     throw `No transforms specified :(
 

--- a/src/parseOptions.js
+++ b/src/parseOptions.js
@@ -40,7 +40,7 @@ program.option('-s, --replaceSaveOriginal <dir>', `in-place transform all *.js f
                          <dir> can also be a single file or a glob pattern
                          makes a copy of each file for comparison prefixed with _original
                          automatically skips node_modules`);
-program.option('-d, --deleteOriginals <dir>', `removes all files prefixed with _original`);
+program.option('-d, --deleteOriginals <dir>', 'removes all files prefixed with _original');
 
 /**
  * Parses and validates command line options from argv.


### PR DESCRIPTION
This adds an option to replace all, but make a copy of the original for comparison.

Currently you have to either transform files one by one and review the changes or blindly overwrite all of them.  This the middle road between the two; automatically replace all files but keep a copy for comparison.

Also adds an option to automatically delete all of the save original copies.