### PR TITLE
Add filter.length to includes transform

### DIFF
--- a/src/transform/includes/comparison.js
+++ b/src/transform/includes/comparison.js
@@ -5,7 +5,7 @@ import {isMinusOne, isZero} from './matchesIndexOf';
  * @param {Object} matches
  * @return {Boolean}
  */
-export function isIncludesComparison({operator, index}) {
+export function isIncludesIndexOfComparison({operator, index}) {
   switch (operator) {
   case '!==':
   case '!=':
@@ -23,12 +23,43 @@ export function isIncludesComparison({operator, index}) {
  * @param {Object} matches
  * @return {Boolean}
  */
-export function isNotIncludesComparison({operator, index}) {
+export function isNotIncludesIndexOfComparison({operator, index}) {
   switch (operator) {
   case '===':
   case '==':
     return isMinusOne(index);
   case '<':
+    return isZero(index);
+  default:
+    return false;
+  }
+}
+
+/**
+ * True when filter().length comparison can be translated to includes()
+ * @param {Object} matches
+ * @return {Boolean}
+ */
+export function isIncludesFilterLengthComparison({operator, index}) {
+  switch (operator) {
+  case '!==':
+  case '!=':
+  case '>':
+    return isZero(index);
+  default:
+    return false;
+  }
+}
+
+/**
+ * True when filter().length comparison can be translated to !includes()
+ * @param {Object} matches
+ * @return {Boolean}
+ */
+export function isNotIncludesFilterLengthComparison({operator, index}) {
+  switch (operator) {
+  case '===':
+  case '==':
     return isZero(index);
   default:
     return false;

--- a/src/transform/includes/index.js
+++ b/src/transform/includes/index.js
@@ -1,16 +1,35 @@
 import traverser from '../../traverser';
 import matchesIndexOf from './matchesIndexOf';
-import {isIncludesComparison, isNotIncludesComparison} from './comparison';
+import isInIfCondition from './isInIfCondition';
+import {
+  matchesFilterLengthRaw, matchesFilterLength
+} from './matchesFilterLength';
+import {
+  isIncludesIndexOfComparison, isNotIncludesIndexOfComparison,
+  isIncludesFilterLengthComparison, isNotIncludesFilterLengthComparison,
+} from './comparison';
 
 export default function(ast) {
   traverser.replace(ast, {
-    enter(node) {
-      const matches = matchesIndexOf(node);
-      if (matches && isIncludesComparison(matches)) {
-        return createIncludes(matches);
+    enter(node, parent) {
+      const matchesI = matchesIndexOf(node);
+      const matchesFLRaw = matchesFilterLengthRaw(node);
+      const matchesFL = matchesFilterLength(node);
+
+      if (matchesI && isIncludesIndexOfComparison(matchesI)) {
+        return createIncludes(matchesI);
       }
-      if (matches && isNotIncludesComparison(matches)) {
-        return createNot(createIncludes(matches));
+      if (matchesI && isNotIncludesIndexOfComparison(matchesI)) {
+        return createNot(createIncludes(matchesI));
+      }
+      if (matchesFLRaw && isInIfCondition(node, parent)) {
+        return createIncludes(matchesFLRaw);
+      }
+      if (matchesFL && isIncludesFilterLengthComparison(matchesFL)) {
+        return createIncludes(matchesFL);
+      }
+      if (matchesFL && isNotIncludesFilterLengthComparison(matchesFL)) {
+        return createNot(createIncludes(matchesFL));
       }
     }
   });

--- a/src/transform/includes/isInIfCondition.js
+++ b/src/transform/includes/isInIfCondition.js
@@ -1,0 +1,17 @@
+import isEqualAst from '../../utils/isEqualAst';
+import {matchesAst, extract} from '../../utils/matchesAst';
+
+/**
+ * True when node is the test expression of an if statement
+ * @param {Object} matches
+ * @return {Boolean}
+ */
+export default function(node, parent) {
+  const matches = matchesAst({
+    type: 'IfStatement',
+    test: extract('test'),
+  })(parent);
+
+  return matches && isEqualAst(node, matches.test);
+}
+

--- a/src/transform/includes/matchesFilterLength.js
+++ b/src/transform/includes/matchesFilterLength.js
@@ -1,0 +1,138 @@
+import isEqualAst from '../../utils/isEqualAst';
+import {matchesAst, matchesLength, extract} from '../../utils/matchesAst';
+
+/**
+ * Matches: -1
+ */
+export const isMinusOne = matchesAst({
+  type: 'UnaryExpression',
+  operator: '-',
+  argument: {
+    type: 'Literal',
+    value: 1
+  },
+  prefix: true
+});
+
+/**
+ * Matches: 0
+ */
+export const isZero = matchesAst({
+  type: 'Literal',
+  value: 0
+});
+
+// Matches: object.filter(param => conditional1 === conditional2).length
+const matchesFilterLengthBody = matchesAst({
+  type: 'MemberExpression',
+  object: {
+    type: 'CallExpression',
+    callee: {
+      type: 'MemberExpression',
+      computed: false,
+      object: extract('object'),
+      property: {
+        type: 'Identifier',
+        name: 'filter'
+      }
+    },
+    arguments: matchesLength([{
+      type: 'ArrowFunctionExpression',
+      params: matchesLength([extract('param')]),
+      body: {
+        type: 'BinaryExpression',
+        left: extract('conditional1'),
+        operator: '===',
+        right: extract('conditional2'),
+      }
+    }]),
+  },
+  property: {
+    type: 'Identifier',
+    name: 'length'
+  }
+});
+
+function findSearchElement({param, conditional1, conditional2}) {
+  if (isEqualAst(param, conditional1)) {
+    return conditional2;
+  }
+
+  if (isEqualAst(param, conditional2)) {
+    return conditional1;
+  }
+  return;
+}
+
+// Matches either of:
+// - object.filter(param => param === searchElement).length
+// - object.filter(param => searchElement === param).length
+export function matchesFilterLengthRaw(node) {
+  const matches = matchesFilterLengthBody(node);
+  const searchElement = findSearchElement(matches);
+  if (matches && searchElement) {
+    matches.searchElement = searchElement;
+    return matches;
+  }
+}
+
+// Matches: 0
+const matchesLengthIdentifier = extract('index', (v) => isZero(v));
+
+// Matches either of:
+// - object.filter(param => param === searchElement).length <operator> index
+// - object.filter(param => searchElement === param).length <operator> index
+const matchesFilterLengthNormal = matchesAst({
+  type: 'BinaryExpression',
+  operator: extract('operator'),
+  left: matchesFilterLengthRaw,
+  right: matchesLengthIdentifier,
+});
+
+// Matches either of:
+// - index <operator> object.filter(param => param === searchElement).length
+// - index <operator> object.filter(param => searchElement === param).length
+const matchesFilterLengthReversed = matchesAst({
+  type: 'BinaryExpression',
+  operator: extract('operator'),
+  left: matchesLengthIdentifier,
+  right: matchesFilterLengthRaw,
+});
+
+// Reverses the direction of comparison operator
+function reverseOperator(operator) {
+  return operator.replace(/[><]/, (op) => op === '>' ? '<' : '>');
+}
+
+function reverseOperatorField(matches) {
+  if (!matches) {
+    return false;
+  }
+
+  return Object.assign({}, matches, {
+    operator: reverseOperator(matches.operator)
+  });
+}
+
+/**
+ * Matches:
+ *
+ *    object.filter(param => param === searchElement).length <operator> index
+ *    object.filter(param => searchElement === param).length <operator> index
+ *    index <operator> object.filter(param => param === searchElement).length
+ * or
+ *    index <operator> object.filter(param => searchElement === param).length
+ *
+ * On success returns object with keys:
+ *
+ * - object
+ * - searchElement
+ * - operator
+ * - index
+ *
+ * @param  {Object} node
+ * @return {Object}
+ */
+export function matchesFilterLength(node) {
+  return matchesFilterLengthNormal(node) || reverseOperatorField(matchesFilterLengthReversed(node));
+}

--- a/test/transform/includesTest.js
+++ b/test/transform/includesTest.js
@@ -192,3 +192,72 @@ describe('indexOf() to includes()', () => {
     });
   });
 });
+
+describe('filter().length to includes()', () => {
+  describe('without a comparison', () => {
+    it('inside an if statement should replace length with includes()', () => {
+      expectTransform(
+        'if (array.filter(foo => foo === bar).length) { /* */ }'
+      ).toReturn(
+        'if (array.includes(bar)) { /* */ }'
+        );
+    });
+
+    it('outside an if statement should NOT transform', () => {
+      expectNoChange(
+        'array.filter(foo => foo === bar).length'
+      );
+    });
+  });
+
+
+  describe('with a comparison', () => {
+    it('> 0 should replace with includes()', () => {
+      expectTransform(
+        'if (array.filter(foo => foo === bar).length > 0) { /* */ }'
+      ).toReturn(
+        'if (array.includes(bar)) { /* */ }'
+        );
+    });
+
+    it('> 0 should replace with includes() in assignments', () => {
+      expectTransform(
+        'const moocow = array.filter(foo => foo === bar).length > 0'
+      ).toReturn(
+        'const moocow = array.includes(bar)'
+        );
+    });
+
+    it('> 0 should replace with includes() in standalone expressions', () => {
+      expectTransform(
+        'array.filter(foo => foo === bar).length > 0'
+      ).toReturn(
+        'array.includes(bar)'
+        );
+    });
+
+    it('> 0 should replace with includes() with comparison swapped', () => {
+      expectTransform(
+        'array.filter(foo => bar === foo).length > 0'
+      ).toReturn(
+        'array.includes(bar)'
+        );
+    });
+
+    it('> 0 should replace with includes() inside objects', () => {
+      expectTransform(
+        'object.attribute.array.filter(foo => bar === foo).length > 0'
+      ).toReturn(
+        'object.attribute.array.includes(bar)'
+        );
+    });
+
+    it('=== 0 should replace with !includes()', () => {
+      expectTransform(
+        'if (array.filter(foo => foo === bar).length === 0) { /* */ }'
+      ).toReturn(
+        'if (!array.includes(bar)) { /* */ }'
+        );
+    });
+  });
+});


### PR DESCRIPTION
One way to check if an array includes an item is to do

```js
if (array.filter(foo => foo === bar).length) { /* */ }
```

rather than

```js
if (array.includes(bar)) { /* */ }
```

This extends the existing `includes` transformation to cover this case.

Fixes #218