### PR TITLE
`no-strict` transform: preserve preceding comments

### DIFF
--- a/src/transform/noStrict.js
+++ b/src/transform/noStrict.js
@@ -1,10 +1,22 @@
 import traverser from '../traverser';
 import isString from '../utils/isString';
+import copyComments from '../utils/copyComments';
 
 export default function(ast) {
   traverser.replace(ast, {
-    enter(node) {
+    enter(node, parent) {
       if (node.type === 'ExpressionStatement' && isUseStrictString(node.expression)) {
+        const index = parent.body.indexOf(node);
+        const next = parent.body[index + 1];
+
+        if (next) {
+          copyComments({
+            from: node,
+            to: next,
+            prepend: true,
+          });
+        }
+
         this.remove();
       }
     }

--- a/src/utils/copyComments.js
+++ b/src/utils/copyComments.js
@@ -1,5 +1,5 @@
 /**
- * Appends comments of one node to comments of another.
+ * Appends (or prepends if specified) comments of one node to comments of another.
  *
  * - Modifies `to` node with added comments.
  * - Does nothing when there are no comments to copy
@@ -7,9 +7,12 @@
  *
  * @param  {Object} from Node to copy comments from
  * @param  {Object} to Node to copy comments to
+ * @param  {Boolean} prepend prepend comments instead of appending
  */
-export default function copyComments({from, to}) {
+export default function copyComments({from, to, prepend}) {
   if (from.comments && from.comments.length > 0) {
-    to.comments = (to.comments || []).concat(from.comments || []);
+    const toComments = to.comments || [];
+    const bothComments = prepend ? [from.comments, toComments] : [toComments, from.comments];
+    to.comments = [].concat(...bothComments);
   }
 }

--- a/test/transform/noStrictTest.js
+++ b/test/transform/noStrictTest.js
@@ -12,6 +12,10 @@ describe('Removal of "use strict"', () => {
     expectTransform('foo();\n"use strict";\nbar();').toReturn('foo();\nbar();');
   });
 
+  it('should not remove comments before "use strict"', () => {
+    expectTransform('// foo();\n"use strict";\nbar();').toReturn('// foo();\nbar();');
+  });
+
   it('should keep "use strict" used inside other code', () => {
     expectNoChange('x = "use strict";');
     expectNoChange('foo("use strict");');


### PR DESCRIPTION
Fixes https://github.com/lebab/lebab/issues/227

I split this into three commits:

1. Adding a test
2. Refactoring copyComments() to allow prepending
3. Fixing the test, using the new copyComments()