### PR TITLE
Make sure warnings cannot cause crash

### DIFF
--- a/src/Logger.js
+++ b/src/Logger.js
@@ -14,7 +14,7 @@ export default class Logger {
    */
   warn(node, msg, type) {
     this.warnings.push({
-      line: node.loc.start.line,
+      line: node.loc ? node.loc.start.line : 0,
       msg,
       type,
     });


### PR DESCRIPTION
Fixes `Cannot read property 'start' of undefined` crash in case there is no `node.loc`, which might happen when using lebab's node API.

Unfortunately I have no good scenario for reproducing the issue. I can just tell you that this may happen in practice when using the node API, thus feeding lebab with already-parsed Babel nodes. I hope you accept the bug fix nevertheless 😉

<img width="517" alt="bildschirmfoto 2017-04-20 um 20 54 52" src="https://cloud.githubusercontent.com/assets/1842462/25247658/bb022170-260b-11e7-8303-280664e58b01.png">
