### PR TITLE
Preserve 'async' anonymous function expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "eslint src/ test/ system-test/ bin/ *.js",
     "prepublish": "rm -rf lib/ && babel src/ --out-dir lib/",
+    "posinstall": "npm run prebublish",
     "system-test": "npm run prepublish && mocha --compilers js:babel-register \"system-test/**/*Test.js\"",
     "//": "Unit tests: a) for single run, b) in watch-mode, c) with coverage.",
     "test": "mocha --compilers js:babel-register \"test/**/*Test.js\"",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "lint": "eslint src/ test/ system-test/ bin/ *.js",
     "prepublish": "rm -rf lib/ && babel src/ --out-dir lib/",
-    "posinstall": "npm run prebublish",
     "system-test": "npm run prepublish && mocha --compilers js:babel-register \"system-test/**/*Test.js\"",
     "//": "Unit tests: a) for single run, b) in watch-mode, c) with coverage.",
     "test": "mocha --compilers js:babel-register \"test/**/*Test.js\"",

--- a/src/syntax/ArrowFunctionExpression.js
+++ b/src/syntax/ArrowFunctionExpression.js
@@ -14,13 +14,14 @@ class ArrowFunctionExpression extends BaseSyntax {
    * @param {Node[]} cfg.defaults
    * @param {Node} cfg.rest (optional)
    */
-  constructor({body, params, defaults, rest}) {
+  constructor({body, params, defaults, rest, async}) {
     super('ArrowFunctionExpression');
 
     this.body = body;
     this.params = params;
     this.defaults = defaults;
     this.rest = rest;
+    this.async = async;
     this.generator = false;
     this.id = undefined;
   }

--- a/src/transform/arrow.js
+++ b/src/transform/arrow.js
@@ -80,6 +80,7 @@ function functionToArrow(func) {
     params: func.params,
     defaults: func.defaults,
     rest: func.rest,
+    async: func.async,
   });
 }
 

--- a/test/transform/arrowTest.js
+++ b/test/transform/arrowTest.js
@@ -20,6 +20,36 @@ describe('Arrow functions', () => {
     expectTransform(script).toReturn('a((b, c) => b);');
   });
 
+  it('should preserve async on anonymous function expression with no argument', () => {
+    const script = 'f = async function() { return 1; };';
+
+    expectTransform(script).toReturn('f = async () => 1;');
+  });
+
+  it('should preserve async on anonymous function expression with single argument', () => {
+    const script = 'f = async function(a) { return a; };';
+
+    expectTransform(script).toReturn('f = async a => a;');
+  });
+
+  it('should preserve async on anonymous function assignment with multiple arguments', () => {
+    const script = 'f = async function(a,b) { return a; };';
+
+    expectTransform(script).toReturn('f = async (a, b) => a;');
+  });
+
+  it('should preserve async on immediate function invocation', () => {
+    const script = '(async function () { await foo(); }());';
+
+    expectTransform(script).toReturn('((async () => { await foo(); })());');
+  });
+
+  it('should preserve async on immediate function invocation with arguments', () => {
+    const script = '(async function (a) { await foo(a); }());';
+
+    expectTransform(script).toReturn('((async a => { await foo(a); })());');
+  });
+
   it('should convert function assignment', () => {
     const script = 'x = function () { foo(); };';
 


### PR DESCRIPTION
The current arrow transform removes the async keyword on anonymous function expressions, which throws a syntax error if there is an await keyword in the body. Generally, async keyword should be preserved whether there is an await keyword in the body or not.
 
```js
const a = async function(){ return await foo(); };
/** becomes like this */
const a = () => await foo();
/** is not a syntax error due to await */
```
This pull fixes those errors and preserves the async keyword.
```js
const a = async function(){ return await foo(); };
/** should preserve async */
const a = async () => await foo();
/** or without await */
const f = async function() { return 1; };
/** should still preserve async */
const f = async () => 1;
```
Also the same with immediate self-invoking async functions
```js
(async function () { await foo(); }());
/** should preserve async */
((async () => { await foo(); })());
```