### PR TITLE
Safe requiring of babel-polyfill

### DIFF
--- a/src/Transformer.js
+++ b/src/Transformer.js
@@ -1,4 +1,9 @@
-import 'babel-polyfill';
+/*eslint-disable */
+if ((typeof window !== 'undefined' && !window['_babelPolyfill']) ||
+  (typeof global !== 'undefined' && !global['_babelPolyfill'])) {
+  require('babel-polyfill');
+}
+/*eslint-enable */
 import recast from 'recast';
 import parser from './Parser';
 import Logger from './Logger';


### PR DESCRIPTION
Fixes https://github.com/lebab/lebab/issues/249
This will make sure that babel-polyfill is imported instead of removing it.