### PR TITLE
Propose using `--replace` for multiple input files

### DIFF
--- a/src/OptionParser.js
+++ b/src/OptionParser.js
@@ -66,7 +66,7 @@ export default class OptionParser {
 
   getInputFile() {
     if (this.program.args.length > 1) {
-      throw `Only one input file allowed, but ${this.program.args.length} given instead.`;
+      throw `Only one input file allowed, but ${this.program.args.length} given. Use --replace <dir> instead.`;
     }
     if (this.program.args[0] && !fs.existsSync(this.program.args[0])) {
       throw `File ${this.program.args[0]} does not exist.`;


### PR DESCRIPTION
People are used to pass multiple input files. It was not obvious to me at first that you need to use a different option for that.

Hopefully an improved error message will help the next guy stumbling upon that 😉