### PR TITLE
Updates and some changes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["es2015"],
+  "presets": ["env"],
   "plugins": [
     "add-module-exports"
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules
 lib
 .nyc_output
 coverage
+*.lcov
+yarn.lock
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - 4
-  - 5
   - 6
-
+  - 8
+  - 9
+  - 10
 cache:
   directories:
   - node_modules

--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ Most of the time there won't be any warnings and the array will be empty.
 
 Alternatively one can use Lebab through plugins in the following editors:
 
-- [Atom](https://github.com/ga2mer/atom-lebab)
-- [Sublime](https://github.com/inkless/lebab-sublime)
-- [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-lebab)
+- Atom: [atom-lebab](https://github.com/ga2mer/atom-lebab)
+- Sublime: [lebab-sublime](https://github.com/inkless/lebab-sublime) or [Lebab ES6 Transform](https://packagecontrol.io/packages/Lebab%20ES6%20Transform)
+- VSCode: [vscode-lebab](https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-lebab)
 
 
 ## What's next?

--- a/package.json
+++ b/package.json
@@ -6,17 +6,17 @@
   "scripts": {
     "lint": "eslint src/ test/ system-test/ bin/ *.js",
     "prepublish": "rm -rf lib/ && babel src/ --out-dir lib/",
-    "system-test": "npm run prepublish && mocha --compilers js:babel-register \"system-test/**/*Test.js\"",
+    "system-test": "npm run prepublish && mocha --require babel-register \"./system-test/**/*Test.js\"",
     "//": "Unit tests: a) for single run, b) in watch-mode, c) with coverage.",
-    "test": "mocha --compilers js:babel-register \"test/**/*Test.js\"",
-    "watch": "mocha --watch --compilers js:babel-register \"test/**/*Test.js\"",
+    "test": "mocha --require babel-register \"./test/**/*Test.js\"",
+    "watch": "mocha --watch --require babel-register \"./test/**/*Test.js\"",
     "coverage": "nyc npm test",
     "///": "These are used by Travis to create coverage report. Run 'coverage' script first.",
     "ensure-coverage": "nyc check-coverage --statements 80 --branches 80 --functions 80",
-    "upload-coverage": "nyc report --reporter=lcov && cat coverage/*/lcov.info | codecov"
+    "upload-coverage": "nyc report --reporter=text-lcov > coverage.lcov codecov"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "files": [
     "lib",
@@ -46,24 +46,24 @@
   },
   "homepage": "https://github.com/mohebifar/lebab",
   "dependencies": {
-    "commander": "^2.11.0",
+    "commander": "^2.15.1",
     "escope": "^3.6.0",
-    "espree": "^3.4.3",
+    "espree": "^3.5.4",
     "estraverse": "^4.1.1",
     "glob": "^7.1.2",
-    "lodash": "^4.17.4",
-    "recast": "^0.12.6"
+    "lodash": "^4.17.10",
+    "recast": "^0.14.7"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.1",
+    "babel-cli": "^6.26.0",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-register": "^6.24.1",
-    "chai": "^4.1.0",
-    "codecov": "^2.2.0",
-    "eslint": "^4.3.0",
+    "babel-preset-env": "^1.7.0",
+    "babel-register": "^6.26.0",
+    "chai": "^4.1.2",
+    "codecov": "^3.0.2",
+    "eslint": "^4.19.1",
     "eslint-plugin-no-null": "^1.0.2",
-    "mocha": "^3.4.2",
-    "nyc": "^11.1.0"
+    "mocha": "^5.1.1",
+    "nyc": "^11.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coverage": "nyc npm test",
     "///": "These are used by Travis to create coverage report. Run 'coverage' script first.",
     "ensure-coverage": "nyc check-coverage --statements 80 --branches 80 --functions 80",
-    "upload-coverage": "nyc report --reporter=text-lcov > coverage.lcov codecov"
+    "upload-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
   },
   "engines": {
     "node": ">=6"

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -1,8 +1,8 @@
 import espree from 'espree';
 
 const ESPREE_OPTS = {
-  ecmaVersion: 8,
-  ecmaFeatures: {jsx: true, experimentalObjectRestSpread: true}
+  ecmaVersion: 9,
+  ecmaFeatures: {jsx: true}
 };
 
 /**

--- a/src/traverser.js
+++ b/src/traverser.js
@@ -4,25 +4,18 @@ import estraverse from 'estraverse';
 // JSX AST types, as documented in:
 // https://github.com/facebook/jsx/blob/master/AST.md
 const jsxExtensionKeys = {
-  JSXIdentifier: [],
-  JSXMemberExpression: ['object', 'property'],
-  JSXNamespacedName: ['namespace', 'name'],
-  JSXEmptyExpression: [],
-  JSXExpressionContainer: ['expression'],
-  JSXOpeningElement: ['name', 'attributes'],
-  JSXClosingElement: ['name'],
-  JSXAttribute: ['name', 'value'],
-  JSXSpreadAttribute: ['argument'],
-  JSXElement: ['openingElement', 'closingElement', 'children'],
-};
-
-const experimentalExtensionKeys = {
-  ExperimentalRestProperty: ['argument'],
-  ExperimentalSpreadProperty: ['argument'],
-};
-
-const extensions = {
-  keys: Object.assign({}, jsxExtensionKeys, experimentalExtensionKeys),
+  keys: {
+    JSXIdentifier: [],
+    JSXMemberExpression: ['object', 'property'],
+    JSXNamespacedName: ['namespace', 'name'],
+    JSXEmptyExpression: [],
+    JSXExpressionContainer: ['expression'],
+    JSXOpeningElement: ['name', 'attributes'],
+    JSXClosingElement: ['name'],
+    JSXAttribute: ['name', 'value'],
+    JSXSpreadAttribute: ['argument'],
+    JSXElement: ['openingElement', 'closingElement', 'children'],
+  }
 };
 
 /**
@@ -40,7 +33,7 @@ export default {
    * @return {Object} The transformed tree
    */
   traverse(tree, cfg) {
-    return estraverse.traverse(tree, Object.assign(cfg, extensions));
+    return estraverse.traverse(tree, Object.assign(cfg, jsxExtensionKeys));
   },
 
   /**
@@ -50,7 +43,7 @@ export default {
    * @return {Object} The transformed tree
    */
   replace(tree, cfg) {
-    return estraverse.replace(tree, Object.assign(cfg, extensions));
+    return estraverse.replace(tree, Object.assign(cfg, jsxExtensionKeys));
   },
 
   /**


### PR DESCRIPTION
Mostly updates all dependencies and change/remove some codes/syntax due to the updated modules.

Changes:
- Updates lebab's dependecies and devDependecies
- Uses babel-preset-env instead of babel-preset-2015 as recommended by babeljs.
- Uses ecmaVersion 9 option for espree, and remove experimental rest,spread options since it is now natively supported by espree using ecmaVersion 9.
- Raise minimum node version to 6, since node version 4 is already on EOL.
- Add travis test for node 8,9,10.
- Use `--require babel-register` option on mocha instead of `--compilers js:babel-register` on package.json file
- Update upload-coverage script syntax
- Add new Sublime Plugin ```Lebab ES6 Transform```

Passes all travis tests.