### PR TITLE
new arrow-return transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,12 @@ The resulting code should be almost 100% equivalent of the original code.
     - [x] not applied to unbound functions that use `this`
     - [x] not applied to functions that use `arguments`
     - [x] not applied to object properties (use `obj-method` transform)
-    - [x] converts immediate return `{ return x; }` to `=> x`
+    - [x] does not convert immediate return
     - [ ] does not remove `that = this` assignments
+- [x] **arrow-return** - return statements on arrow functions
+    - [x] converts immediate return { return x; } to => x
+    - [x] applies to arrow functions and nested arrow functions
+    - [ ] LIMITATION only applies to arrow functions (run the `arrow` transform first)
 - [x] **for-of** - for loop to for-of loop
     - [x] uses name `item` for loop variable when loop body begins with `var item = array[i];`
     - [ ] [does not work when no such alias defined at the start of loop body][166]
@@ -173,8 +177,8 @@ Simply import and call `lebab.transform()`:
 
 ```js
 import lebab from 'lebab';
-const {code, warnings} = lebab.transform('var f = function(){};', ['let', 'arrow']);
-console.log(code); // -> "const f = () => {};"
+const {code, warnings} = lebab.transform('var f = function(a) { return a; };', ['let', 'arrow', 'arrow-return']);
+console.log(code); // -> "const f = a => a;"
 ```
 
 The warnings will be an array of objects like:

--- a/src/OptionParser.js
+++ b/src/OptionParser.js
@@ -8,6 +8,7 @@ const transformsDocs = `
   Safe transforms:
 
     + arrow .......... callback to arrow function
+    + arrow-return ... return statements on arrow functions
     + for-of ......... for loop to for-of loop
     + for-each ....... for loop to Array.forEach()
     + arg-rest ....... use of arguments to function(...args)

--- a/src/builtinTransforms.js
+++ b/src/builtinTransforms.js
@@ -3,6 +3,7 @@ import Transformer from './Transformer';
 import classTransform from './transform/class';
 import templateTransform from './transform/template';
 import arrowTransform from './transform/arrow';
+import arrowReturnTransform from './transform/arrowReturn';
 import letTransform from './transform/let';
 import defaultParamTransform from './transform/defaultParam';
 import destructParamTransform from './transform/destructParam';
@@ -22,6 +23,7 @@ const transformsMap = {
   'class': classTransform,
   'template': templateTransform,
   'arrow': arrowTransform,
+  'arrow-return': arrowReturnTransform,
   'let': letTransform,
   'default-param': defaultParamTransform,
   'destruct-param': destructParamTransform,

--- a/src/transform/arrow.js
+++ b/src/transform/arrow.js
@@ -1,8 +1,7 @@
 import {matches} from 'lodash/fp';
 import traverser from '../traverser';
 import ArrowFunctionExpression from '../syntax/ArrowFunctionExpression';
-import {matchesAst, isAstMatch, matchesLength, extract} from '../utils/matchesAst';
-import copyComments from '../utils/copyComments';
+import {isAstMatch, extract} from '../utils/matchesAst';
 
 export default function(ast, logger) {
   traverser.replace(ast, {
@@ -76,7 +75,7 @@ function hasInFunctionBody(ast, pattern) {
 
 function functionToArrow(func) {
   return new ArrowFunctionExpression({
-    body: extractArrowBody(func.body),
+    body: func.body,
     params: func.params,
     defaults: func.defaults,
     rest: func.rest,
@@ -84,24 +83,3 @@ function functionToArrow(func) {
   });
 }
 
-const matchesReturnBlock = matchesAst({
-  type: 'BlockStatement',
-  body: matchesLength([
-    extract('returnStatement', {
-      type: 'ReturnStatement',
-      argument: extract('returnVal')
-    })
-  ])
-});
-
-function extractArrowBody(block) {
-  const {returnStatement, returnVal} = matchesReturnBlock(block) || {};
-  if (returnVal) {
-    // preserve return statement comments
-    copyComments({from: returnStatement, to: returnVal});
-    return returnVal;
-  }
-  else {
-    return block;
-  }
-}

--- a/src/transform/arrowReturn.js
+++ b/src/transform/arrowReturn.js
@@ -1,0 +1,60 @@
+import {matches} from 'lodash/fp';
+import traverser from '../traverser';
+import {matchesAst, matchesLength, extract} from '../utils/matchesAst';
+import copyComments from '../utils/copyComments';
+
+export default function(ast) {
+  traverser.replace(ast, {
+    enter(node, parent) {
+      if (isArrowFunction(node, parent)) {
+        return arrowReturn(node);
+      }
+    }
+  });
+}
+
+function arrowReturn(node) {
+  node.body = extractArrowBody(node.body);
+  return node;
+}
+
+function isArrowFunction(node, parent) {
+  return node.type === 'ArrowFunctionExpression' &&
+    parent.type !== 'Property' &&
+    parent.type !== 'MethodDefinition' &&
+    !node.id &&
+    !node.generator &&
+    !hasThis(node.body);
+}
+
+function hasThis(ast) {
+  return hasInFunctionBody(ast, {type: 'ThisExpression'});
+}
+
+function hasInFunctionBody(ast, pattern) {
+  return traverser.find(ast, matches(pattern), {
+    skipTypes: ['FunctionExpression', 'FunctionDeclaration']
+  });
+}
+
+const matchesReturnBlock = matchesAst({
+  type: 'BlockStatement',
+  body: matchesLength([
+    extract('returnStatement', {
+      type: 'ReturnStatement',
+      argument: extract('returnVal')
+    })
+  ])
+});
+
+function extractArrowBody(block) {
+  const {returnStatement, returnVal} = matchesReturnBlock(block) || {};
+  if (returnVal) {
+    // preserve return statement comments
+    copyComments({from: returnStatement, to: returnVal});
+    return returnVal;
+  }
+  else {
+    return block;
+  }
+}

--- a/system-test/binTest.js
+++ b/system-test/binTest.js
@@ -28,7 +28,7 @@ describe('Smoke test for the executable script', function() {
 
         expect(fs.readFileSync('test/output.js').toString()).to.equal(
           'const foo = 10;\n' +
-          '[1, 2, 3].map(x => x*x);'
+          '[1, 2, 3].map(x => { return x*x });'
         );
         done();
       });
@@ -44,7 +44,7 @@ describe('Smoke test for the executable script', function() {
 
         expect(fs.readFileSync('test/output.js').toString()).to.equal(
           'const foo = 10;\n' +
-          '[1, 2, 3].map(x => x*x);'
+          '[1, 2, 3].map(x => { return x*x });'
         );
         done();
       });

--- a/test/transform/arrowReturnTest.js
+++ b/test/transform/arrowReturnTest.js
@@ -1,0 +1,74 @@
+import createTestHelpers from '../createTestHelpers';
+const {expectTransform, expectNoChange} = createTestHelpers(['arrow-return']);
+
+describe('Arrow functions with return', () => {
+  it('should handle simple return callbacks', () => {
+    const script = 'setTimeout(() => { return 2; });';
+    expectTransform(script).toReturn('setTimeout(() => 2);');
+  });
+  it('should handle return statements on immediately returning function expressions', () => {
+    const script = 'a(() => { return 123; });';
+    expectTransform(script).toReturn('a(() => 123);');
+  });
+
+  it('should handle return statements on immediately returning function declarations', () => {
+    const script = 'const a = () => { return 123; }';
+    expectTransform(script).toReturn('const a = () => 123');
+  });
+
+  it('should handle return statements inside a nested arrow function', () => {
+    const script = 'a(() => { return () => { const b = c => { return c; } }; })';
+    expectTransform(script).toReturn('a(() => () => { const b = c => c })');
+  });
+
+  it('should handle returning functions using `this` keyword inside a nested function', () => {
+    const script = 'a(() => { return function() { this; }; });';
+    expectTransform(script).toReturn('a(() => function() { this; });');
+  });
+
+  it('should handle returning functions using `arguments` inside a nested function', () => {
+    const script = 'a(() => { return function() { arguments; }; });';
+    expectTransform(script).toReturn('a(() => function() { arguments; });');
+  });
+
+  it('should handle returning an object', () => {
+    const script = 'var f = a => { return {a: 1}; };';
+    expectTransform(script).toReturn(
+      'var f = a => ({\n' +
+      '  a: 1\n' +
+      '});'
+    );
+  });
+
+  it('should handle return statements inside a parenthesized arrow function', () => {
+    const script = 'const x = (a => { return a; }).call(null, 1);';
+    expectTransform(script).toReturn('const x = ((a => a)).call(null, 1);');
+  });
+
+  it('should handle return statements from shorthand notation and preserving comments', () => {
+    expectTransform(
+      'a(b => {\n' +
+      '  // comment\n' +
+      '  return b;\n' +
+      '});'
+    ).toReturn(
+      'a(b => // comment\n' +
+      'b);'
+    );
+  });
+
+  it('should not convert return statements from non-arrow function', () => {
+    expectNoChange('const a = function(b) { return b; };');
+  });
+
+  it('should not convert return statements from non-arrow function inside a nested arrow function', () => {
+    expectNoChange('const a = b => { const c = function(d) { return d; } };');
+  });
+
+  it('should preserve code after return statement', () => {
+    expectNoChange('a(() => {\n' +
+      '  return func;\n' +
+      '  function func() {}\n' +
+      '});');
+  });
+});

--- a/test/transform/arrowTest.js
+++ b/test/transform/arrowTest.js
@@ -5,57 +5,47 @@ describe('Arrow functions', () => {
   it('should convert simple callbacks', () => {
     const script = 'setTimeout(function() { return 2; });';
 
-    expectTransform(script).toReturn('setTimeout(() => 2);');
+    expectTransform(script).toReturn('setTimeout(() => { return 2; });');
   });
 
   it('should convert callbacks with a single argument', () => {
     const script = 'a(function(b) { return b; });';
 
-    expectTransform(script).toReturn('a(b => b);');
+    expectTransform(script).toReturn('a(b => { return b; });');
   });
 
   it('should convert callbacks with multiple arguments', () => {
     const script = 'a(function(b, c) { return b; });';
 
-    expectTransform(script).toReturn('a((b, c) => b);');
-  });
-
-  it('should handle returning an object', () => {
-    const script = 'var f = function(a) { return {a: 1}; };';
-
-    expectTransform(script).toReturn(
-      'var f = a => ({\n' +
-      '  a: 1\n' +
-      '});'
-    );
+    expectTransform(script).toReturn('a((b, c) => { return b; });');
   });
 
   it.skip('should handle returning an object property access', () => {
     const script = 'var f = function(a) { return {a: 1}[a]; };';
 
     expectTransform(script).toReturn(
-      'var f = a => ({\n' +
+      'var f = a => { return {\n' +
       '  a: 1\n' +
-      '}[a]);'
+      '}[a]; };'
     );
   });
 
   it('should preserve async on anonymous function expression with no argument', () => {
     const script = 'f = async function() { return 1; };';
 
-    expectTransform(script).toReturn('f = async () => 1;');
+    expectTransform(script).toReturn('f = async () => { return 1; };');
   });
 
   it('should preserve async on anonymous function expression with single argument', () => {
     const script = 'f = async function(a) { return a; };';
 
-    expectTransform(script).toReturn('f = async a => a;');
+    expectTransform(script).toReturn('f = async a => { return a; };');
   });
 
   it('should preserve async on anonymous function assignment with multiple arguments', () => {
     const script = 'f = async function(a,b) { return a; };';
 
-    expectTransform(script).toReturn('f = async (a, b) => a;');
+    expectTransform(script).toReturn('f = async (a, b) => { return a; };');
   });
 
   it('should preserve async on immediate function invocation', () => {
@@ -91,13 +81,13 @@ describe('Arrow functions', () => {
   it('should convert functions using `this` keyword inside a nested function', () => {
     const script = 'a(function () { return function() { this; }; });';
 
-    expectTransform(script).toReturn('a(() => function() { this; });');
+    expectTransform(script).toReturn('a(() => { return function() { this; }; });');
   });
 
   it('should convert functions using `arguments` inside a nested function', () => {
     const script = 'a(function () { return function() { arguments; }; });';
 
-    expectTransform(script).toReturn('a(() => function() { arguments; });');
+    expectTransform(script).toReturn('a(() => { return function() { arguments; }; });');
   });
 
   it('should preserve default parameters', () => {
@@ -193,7 +183,7 @@ describe('Arrow functions', () => {
       expectTransform(
         'a(function () { return 123; }.bind(this));'
       ).toReturn(
-        'a(() => 123);'
+        'a(() => { return 123; });'
       );
     });
 
@@ -225,7 +215,7 @@ describe('Arrow functions', () => {
       expectTransform(
         'x = function(a) { return a; }.call(null, 1);'
       ).toReturn(
-        'x = (a => a).call(null, 1);'
+        'x = (a => { return a; }).call(null, 1);'
       );
     });
   });
@@ -238,8 +228,10 @@ describe('Arrow functions', () => {
         '  return b;\n' +
         '});'
       ).toReturn(
-        'a(b => // comment\n' +
-        'b);'
+        'a(b => {\n' +
+        '  // comment\n' +
+        '  return b;\n' +
+        '});'
       );
     });
   });


### PR DESCRIPTION
This is in reference to PR #262 which is basically a limitation of Lebab not handling ```immediate return statements``` of an ```arrow function```

Example:
Lebab does not convert the return statement of the code below
```js
const actionCreator = () => {
  return {
    type: 'ADD_COUNTER',
    payload: { count: 1}
  }
}
```
However, the code above is still a valid es6 code, therefor, separating the handling of return statements from the ```arrow``` transform is preferable because it gives the users the freedom to have their return statements preserved (for readability)  or converted (for simplicity)

This PR moves the handling of return statements from the ```arrow``` transform to a separate transform called ```arrow-return```.  Also adds arrowReturnTest and update arrowTest's return statements.

Pros:
- It converts return statements of an ```arrow function```
- it converts return statements of nested ```arrow functions```
- freedom to choose between readability and simplicity

Cons:
- extra transform code/option
- only works for ```arrow functions```(obviously) so it is advised to run ```arrow``` transform first

Travis build passed.

