### PR TITLE
Update badge links to use HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://img.shields.io/travis/lebab/lebab.svg)](http://travis-ci.org/lebab/lebab)
+[![Build Status](https://img.shields.io/travis/lebab/lebab.svg)](https://travis-ci.org/lebab/lebab)
 [![Coverage Status](https://img.shields.io/codecov/c/github/lebab/lebab/master.svg)](https://codecov.io/github/lebab/lebab)
 [![Dependencies](https://img.shields.io/librariesio/github/lebab/lebab.svg)](https://libraries.io/npm/lebab)
-[![License](http://img.shields.io/:license-mit-brightgreen.svg)](http://mohebifar.mit-license.org)
-[![JS.ORG](https://img.shields.io/badge/js.org-xto6-ffb400.svg)](http://js.org)
+[![License](https://img.shields.io/:license-mit-brightgreen.svg)](https://mohebifar.mit-license.org)
+[![JS.ORG](https://img.shields.io/badge/js.org-xto6-ffb400.svg)](https://js.org)
 [![Version](https://img.shields.io/npm/v/lebab.svg)](https://www.npmjs.com/package/lebab)
 
 # Lebab


### PR DESCRIPTION
On [npmjs.com](https://www.npmjs.com/package/lebab) and [yarnpkg.com](https://yarnpkg.com/en/package/lebab), the HTTP license badge is showing a warning for mixed-content.

I also updated the other links that support HTTPS.