### PR TITLE
Skip default-param for non-BlockStatement body

### DIFF
--- a/src/transform/defaultParam/index.js
+++ b/src/transform/defaultParam/index.js
@@ -11,7 +11,7 @@ import matchIfUndefinedAssignment from './matchIfUndefinedAssignment';
 export default function(ast) {
   traverser.replace(ast, {
     enter(node) {
-      if (isFunction(node)) {
+      if (isFunction(node) && node.body.type === 'BlockStatement') {
         transformDefaultParams(node);
       }
     }
@@ -70,7 +70,6 @@ function containsParams(defaultValue, params) {
 // Returns a map of variable-name:{name, value, node}
 function findDefaults(fnBody) {
   const defaults = {};
-
   for (const node of fnBody) {
     const def = matchDefaultAssignment(node);
     if (!def) {

--- a/test/transform/defaultParamTest.js
+++ b/test/transform/defaultParamTest.js
@@ -341,4 +341,10 @@ describe('Default parameters', () => {
       'function f(a, {b = 1}) { a = a || b }'
     );
   });
+
+  it('should skip transform if function body type is not a BlockStatement', () => {
+    expectNoChange(
+      'const f = function(a) { return a }'
+    );
+  });
 });

--- a/test/transform/defaultParamTest.js
+++ b/test/transform/defaultParamTest.js
@@ -344,7 +344,7 @@ describe('Default parameters', () => {
 
   it('should skip transform if function body type is not a BlockStatement', () => {
     expectNoChange(
-      'const f = function(a) { return a }'
+      'const f = (a) => a'
     );
   });
 });


### PR DESCRIPTION
This PR adds additional condition which checks if the function's body type is a `BlockStatement` and if not it skips this function. 

Problem: The current logic only checks if a node is a function and assumes that the body type is a `BlockStatement` which is not always the case for an Immediate-return `ArrowFunctionExpression`, since it removes the `{ ... }` and because of that it is no longer considered as a `BlockStatement`, as `BlockStatement` is usually delimited by `{ ... }`

However, this error will not occur if `arrow-return` transform is not used or `default-param` is used before `arrow-return`

Examples: 
```js
// all examples bellow will throw an error
const a = (x) => x; 
const b = () => 1 
const c = () => new Promise()
const d = (y) => [y]
// and so on...
```