### PR TITLE
[class] Prevent lebab from crashing when using anonymous function declaration on default export

### DIFF
--- a/src/transform/class/matchFunctionDeclaration.js
+++ b/src/transform/class/matchFunctionDeclaration.js
@@ -10,7 +10,7 @@
  * @return {Object}
  */
 export default function(node) {
-  if (node.type === 'FunctionDeclaration') {
+  if (node.type === 'FunctionDeclaration' && node.id) {
     return {
       className: node.id.name,
       constructorNode: node

--- a/test/transform/classTest.js
+++ b/test/transform/classTest.js
@@ -32,6 +32,12 @@ describe('Classes', () => {
     );
   });
 
+  it('should ignore anonymous function declaration', () => {
+    expectNoChange(
+      'export default function () {}'
+    );
+  });
+
   describe('assignment to prototype field', () => {
     it('should convert to class (when function declaration used)', () => {
       expectTransform(


### PR DESCRIPTION
Fixes a bug on Lebab where in it throws a `SyntaxError` when `class` transform is enabled and the user is using anonymous function declaration on default export.

example:
```js
export default function() {}
```
- will throw `SyntaxError Cannot read property 'name' of null` when `class` transform is enabled