### PR TITLE
feat: support passing custom parser to recast

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ import {transform} from 'lebab';
 const {code, warnings} = transform(
   'var f = function(a) { return a; };', // code to transform
   ['let', 'arrow', 'arrow-return'] // transforms to apply
+  { // options
+    parser: ... // custom parser compatible with recast
+  }
 );
 console.log(code); // -> "const f = a => a;"
 ```

--- a/index.js
+++ b/index.js
@@ -8,8 +8,9 @@ const createTransformer = require('./lib/createTransformer').default;
  *
  * @param  {String} code The code to transform
  * @param  {String[]} transformNames The transforms to apply
+ * @param  {Object} options Options to configure the transforms
  * @return {Object} An object with code and warnings props
  */
-exports.transform = function(code, transformNames) {
-  return createTransformer(transformNames).run(code);
+exports.transform = function(code, transformNames, options) {
+  return createTransformer(transformNames, options).run(code);
 };

--- a/src/Transformer.js
+++ b/src/Transformer.js
@@ -8,13 +8,15 @@ import Logger from './Logger';
 export default class Transformer {
   /**
    * @param {Function[]} transforms List of transforms to perform
+   * @param {Object} options Options to configure the transforms
    */
-  constructor(transforms = []) {
+  constructor(transforms = [], options = {}) {
     this.transforms = transforms;
+    this.parser = options.parser || parser;
   }
 
   /**
-   * Tranforms code using all configured transforms.
+   * Transform code using all configured transforms.
    *
    * @param {String} code Input ES5 code
    * @return {Object} Output ES6 code
@@ -30,7 +32,7 @@ export default class Transformer {
 
   applyAllTransforms(code, logger) {
     return this.ignoringHashBangComment(code, (js) => {
-      const ast = parse(js, {parser});
+      const ast = parse(js, {parser: this.parser});
 
       this.transforms.forEach(transformer => {
         transformer(ast.program, logger);

--- a/src/createTransformer.js
+++ b/src/createTransformer.js
@@ -44,11 +44,12 @@ const transformsMap = {
  * Factory for creating a Transformer
  * by just specifying the names of the transforms.
  * @param  {String[]} transformNames
+ * @param  {Object} options
  * @return {Transformer}
  */
-export default function createTransformer(transformNames) {
+export default function createTransformer(transformNames, options) {
   validate(transformNames);
-  return new Transformer(transformNames.map(name => transformsMap[name]));
+  return new Transformer(transformNames.map(name => transformsMap[name]), options);
 }
 
 function validate(transformNames) {


### PR DESCRIPTION
closes #352 

This PR adds a third argument `options` to the `transform` method. User can pass any `parser` that is compatible with recast ([example](https://github.com/benjamn/recast/tree/master/parsers)), this `parser` should have a `parse` method that accepts code and returns AST.

Qustions:
1. `destructParam` imports the internal parser to parse the code, which is not covered by this PR. I'm not sure if I should change the transformer interface from `function(ast, logger)` to `function(ast, logger, parser)` so that the parser config can cover all of the usage.