### PR TITLE
refactor: migrate to `@babel/parser`

### DIFF
--- a/src/Transformer.js
+++ b/src/Transformer.js
@@ -1,5 +1,4 @@
 import {parse, print} from 'recast';
-import parser from './Parser';
 import Logger from './Logger';
 
 /**
@@ -30,7 +29,7 @@ export default class Transformer {
 
   applyAllTransforms(code, logger) {
     return this.ignoringHashBangComment(code, (js) => {
-      const ast = parse(js, {parser});
+      const ast = parse(js, {parser: require('recast/parsers/babel')});
 
       this.transforms.forEach(transformer => {
         transformer(ast.program, logger);

--- a/src/syntax/ImportDeclaration.js
+++ b/src/syntax/ImportDeclaration.js
@@ -8,7 +8,7 @@ class ImportDeclaration extends BaseSyntax {
   /**
    * @param {Object} cfg
    * @param {ImportSpecifier[]|ImportDefaultSpecifier[]} cfg.specifiers
-   * @param {Literal} cfg.source String literal containing library path
+   * @param {StringLiteral} cfg.source String literal containing library path
    */
   constructor({specifiers, source}) {
     super('ImportDeclaration');

--- a/src/transform/argRest.js
+++ b/src/transform/argRest.js
@@ -5,7 +5,7 @@ import withScope from '../withScope';
 export default function(ast) {
   traverser.replace(ast, withScope(ast, {
     enter(node, parent, scope) {
-      if (isES5Function(node) && node.params.length === 0) {
+      if (isFunctionAllowsArguments(node) && node.params.length === 0) {
         const argumentsVar = find(v => v.name === 'arguments', scope.variables);
         // Look through all the places where arguments is used:
         // Make sure none of these has access to some already existing `args` variable
@@ -26,8 +26,8 @@ export default function(ast) {
   }));
 }
 
-function isES5Function(node) {
-  return node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression';
+function isFunctionAllowsArguments(node) {
+  return node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression' || node.type === 'ClassMethod';
 }
 
 function hasArgs(scope) {

--- a/src/transform/argSpread.js
+++ b/src/transform/argSpread.js
@@ -55,9 +55,7 @@ const isUndefined = matches({
 });
 
 const isNull = matches({
-  type: 'Literal',
-  value: null, // eslint-disable-line no-null/no-null
-  raw: 'null'
+  type: 'NullLiteral',
 });
 
 function matchFunctionApplyCall(node) {

--- a/src/transform/arrow.js
+++ b/src/transform/arrow.js
@@ -25,7 +25,7 @@ export default function(ast, logger) {
 
 function isFunctionConvertableToArrow(node, parent) {
   return node.type === 'FunctionExpression' &&
-    parent.type !== 'Property' &&
+    parent.type !== 'ObjectProperty' &&
     parent.type !== 'MethodDefinition' &&
     !node.id &&
     !node.generator &&
@@ -89,6 +89,9 @@ function functionToArrow(func, parent) {
   // by forcing Recast to reformat the CallExpression
   if (isIIFE(func, parent)) {
     parent.original = null; // eslint-disable-line no-null/no-null
+    if (parent.extra) {
+      delete parent.extra.parenthesized;
+    }
   }
 
   return arrow;

--- a/src/transform/class/inheritance/ImportUtilDetector.js
+++ b/src/transform/class/inheritance/ImportUtilDetector.js
@@ -42,7 +42,7 @@ export default class ImportUtilDetector {
         }
       ]),
       source: {
-        type: 'Literal',
+        type: 'StringLiteral',
         value: 'util'
       }
     }, node);

--- a/src/transform/class/inheritance/RequireUtilDetector.js
+++ b/src/transform/class/inheritance/RequireUtilDetector.js
@@ -47,7 +47,7 @@ export default class RequireUtilDetector {
           name: 'require'
         },
         arguments: matchesLength([{
-          type: 'Literal',
+          type: 'StringLiteral',
           value: 'util'
         }])
       }

--- a/src/transform/class/inheritance/RequireUtilInheritsDetector.js
+++ b/src/transform/class/inheritance/RequireUtilInheritsDetector.js
@@ -42,7 +42,7 @@ export default class RequireUtilInheritsDetector {
             name: 'require'
           },
           arguments: matchesLength([{
-            type: 'Literal',
+            type: 'StringLiteral',
             value: 'util'
           }])
         },

--- a/src/transform/class/isFunctionProperty.js
+++ b/src/transform/class/isFunctionProperty.js
@@ -8,7 +8,7 @@ import isTransformableToMethod from './isTransformableToMethod';
  * @return {Boolean}
  */
 export default matches({
-  type: 'Property',
+  type: 'ObjectProperty',
   key: {
     type: 'Identifier',
     // name: <ident>

--- a/src/transform/class/matchObjectDefinePropertyCall.js
+++ b/src/transform/class/matchObjectDefinePropertyCall.js
@@ -31,7 +31,7 @@ const matchObjectDefinePropertyCall = matches({
         }
       },
       {
-        type: 'Literal',
+        type: 'StringLiteral',
         value: extractAny('methodName')
       },
       {

--- a/src/transform/class/matchPrototypeObjectAssignment.js
+++ b/src/transform/class/matchPrototypeObjectAssignment.js
@@ -20,9 +20,18 @@ const matchPrototypeObjectAssignment = matches({
     operator: '=',
     right: {
       type: 'ObjectExpression',
-      properties: extract('properties', props => props.every(isFunctionProperty))
+      properties: extract('properties', props => props.every((node) => isFunctionProperty(node) || isObjectMethod(node)))
     }
   }
+});
+
+const isObjectMethod = matches({
+  type: 'ObjectMethod',
+  key: {
+    type: 'Identifier',
+    // name: <ident>
+  },
+  computed: false,
 });
 
 /**
@@ -50,6 +59,14 @@ export default function(node) {
     return {
       className: className,
       methods: properties.map(prop => {
+        if (prop.type === 'ObjectMethod') {
+          return {
+            propertyNode: prop,
+            methodName: prop.key.name,
+            methodNode: prop,
+            kind: prop.kind,
+          };
+        }
         return {
           propertyNode: prop,
           methodName: prop.key.name,

--- a/src/transform/commonjs/matchRequire.js
+++ b/src/transform/commonjs/matchRequire.js
@@ -5,9 +5,9 @@ const isIdentifier = matches({
   type: 'Identifier'
 });
 
-// matches Property with Identifier key and value (possibly shorthand)
+// matches ObjectProperty with Identifier key and value (possibly shorthand)
 const isSimpleProperty = matches({
-  type: 'Property',
+  type: 'ObjectProperty',
   key: isIdentifier,
   computed: false,
   value: isIdentifier

--- a/src/transform/defaultParam/matchIfUndefinedAssignment.js
+++ b/src/transform/defaultParam/matchIfUndefinedAssignment.js
@@ -26,7 +26,7 @@ const matchTypeofUndefined = matches({
   },
   operator: extractAny('operator'),
   right: {
-    type: 'Literal',
+    type: 'StringLiteral',
     value: 'undefined'
   }
 });

--- a/src/transform/includes/matchesIndexOf.js
+++ b/src/transform/includes/matchesIndexOf.js
@@ -7,7 +7,7 @@ export const isMinusOne = matches({
   type: 'UnaryExpression',
   operator: '-',
   argument: {
-    type: 'Literal',
+    type: 'NumericLiteral',
     value: 1
   },
   prefix: true
@@ -17,7 +17,7 @@ export const isMinusOne = matches({
  * Matches: 0
  */
 export const isZero = matches({
-  type: 'Literal',
+  type: 'NumericLiteral',
   value: 0
 });
 

--- a/src/transform/noStrict.js
+++ b/src/transform/noStrict.js
@@ -1,11 +1,10 @@
 import traverser from '../traverser';
-import isString from '../utils/isString';
 import copyComments from '../utils/copyComments';
 
 export default function(ast) {
   traverser.replace(ast, {
     enter(node, parent) {
-      if (node.type === 'ExpressionStatement' && isUseStrictString(node.expression)) {
+      if (node.type === 'Directive' && node.value.type === 'DirectiveLiteral' && node.value.value === 'use strict') {
         copyComments({
           from: node,
           to: parent,
@@ -15,8 +14,4 @@ export default function(ast) {
       }
     }
   });
-}
-
-function isUseStrictString(node) {
-  return isString(node) && node.value === 'use strict';
 }

--- a/src/transform/objMethod.js
+++ b/src/transform/objMethod.js
@@ -2,7 +2,7 @@ import {matches, extractAny} from 'f-matches';
 import traverser from '../traverser';
 
 const matchTransformableProperty = matches({
-  type: 'Property',
+  type: 'ObjectProperty',
   key: {
     type: 'Identifier',
   },

--- a/src/transform/objShorthand.js
+++ b/src/transform/objShorthand.js
@@ -7,7 +7,7 @@ export default function(ast) {
 }
 
 function propertyToShorthand(node) {
-  if (node.type === 'Property' && equalIdentifiers(node.key, node.value)) {
+  if (node.type === 'ObjectProperty' && equalIdentifiers(node.key, node.value)) {
     node.shorthand = true;
   }
 }

--- a/src/transform/template.js
+++ b/src/transform/template.js
@@ -71,12 +71,12 @@ function splitQuasisAndExpressions(operands) {
 
     if (isString(curr)) {
       let currVal = curr.value;
-      let currRaw = escapeForTemplate(curr.raw);
+      let currRaw = escapeForTemplate(curr.extra.raw);
 
       while (isString(operands[i + 1] || {})) {
         i++;
         currVal += operands[i].value;
-        currRaw += escapeForTemplate(operands[i].raw);
+        currRaw += escapeForTemplate(operands[i].extra.raw);
       }
 
       quasis.push(new TemplateElement({
@@ -93,6 +93,13 @@ function splitQuasisAndExpressions(operands) {
         quasis.push(new TemplateElement({
           tail: operands[i + 1] === undefined
         }));
+      }
+
+      // Get rid of extra parentheses around the expression
+      // by forcing Recast to trigger reformatting
+      curr.original = null; // eslint-disable-line no-null/no-null
+      if (curr.extra) {
+        delete curr.extra.parenthesized;
       }
 
       expressions.push(curr);

--- a/src/traverser.js
+++ b/src/traverser.js
@@ -5,6 +5,7 @@ import estraverse from 'estraverse';
 // https://github.com/facebook/jsx/blob/master/AST.md
 const jsxExtensionKeys = {
   keys: {
+    ...require('@babel/types').VISITOR_KEYS,
     JSXIdentifier: [],
     JSXMemberExpression: ['object', 'property'],
     JSXNamespacedName: ['namespace', 'name'],

--- a/src/utils/destructuring.js
+++ b/src/utils/destructuring.js
@@ -22,7 +22,7 @@ export function extractVariables(node) {
   if (node.type === 'ObjectPattern') {
     return flatMap(extractVariables, node.properties);
   }
-  if (node.type === 'Property') {
+  if (node.type === 'ObjectProperty') {
     return extractVariables(node.value);
   }
   if (node.type === 'AssignmentPattern') {

--- a/src/utils/isString.js
+++ b/src/utils/isString.js
@@ -4,5 +4,5 @@
  * @return {Boolean}
  */
 export default function isString(node) {
-  return node.type === 'Literal' && typeof node.value === 'string';
+  return node.type === 'StringLiteral';
 }

--- a/src/utils/matchAliasedForLoop.js
+++ b/src/utils/matchAliasedForLoop.js
@@ -18,7 +18,7 @@ const matchPlusOne = matches({
     type: 'Identifier',
   }),
   right: {
-    type: 'Literal',
+    type: 'NumericLiteral',
     value: 1
   }
 });
@@ -47,7 +47,7 @@ const matchLooseForLoop = matches({
           type: 'Identifier',
         }),
         init: {
-          type: 'Literal',
+          type: 'NumericLiteral',
           value: 0,
         }
       }

--- a/src/utils/variableType.js
+++ b/src/utils/variableType.js
@@ -51,5 +51,5 @@ function isPropertyInMemberExpression(node, parent) {
 }
 
 function isPropertyInObjectLiteral(node, parent) {
-  return parent.type === 'Property' && parent.key === node;
+  return parent.type === 'ObjectProperty' && parent.key === node;
 }

--- a/test/transform/noStrictTest.js
+++ b/test/transform/noStrictTest.js
@@ -16,12 +16,14 @@ describe('Removal of "use strict"', () => {
     );
 
     expectTransform(
-      'foo();\n' +
-      '"use strict";\n' +
-      'bar();'
+      'function foo() {\n' +
+      '  "use strict";\n' +
+      '  bar();\n' +
+      '}'
     ).toReturn(
-      'foo();\n' +
-      'bar();'
+      'function foo() {\n' +
+      '  bar();\n' +
+      '}'
     );
   });
 

--- a/test/transform/templateTest.js
+++ b/test/transform/templateTest.js
@@ -31,7 +31,7 @@ describe('Template string', () => {
     );
   });
 
-  it('should convert parenthized string concatenations', () => {
+  it('should convert parenthesized string concatenations', () => {
     expectTransform(
       '"str1 " + (x + " str2");'
     ).toReturn(
@@ -39,7 +39,7 @@ describe('Template string', () => {
     );
   });
 
-  it('should convert parenthized string concatenations and other concatenations', () => {
+  it('should convert parenthesized string concatenations and other concatenations', () => {
     expectTransform(
       'x + " str1 " + (y + " str2");'
     ).toReturn(
@@ -47,7 +47,7 @@ describe('Template string', () => {
     );
   });
 
-  it('should convert parenthized non-string concatenations', () => {
+  it('should convert parenthesized non-string concatenations', () => {
     expectTransform(
       '(x + y) + " string " + (a + b);'
     ).toReturn(
@@ -55,7 +55,7 @@ describe('Template string', () => {
     );
   });
 
-  it('should convert non-parenthized non-string concatenations', () => {
+  it('should convert non-parenthesized non-string concatenations', () => {
     expectTransform(
       'x + y + " string " + a + b;'
     ).toReturn(


### PR DESCRIPTION
This PR replaces the existing parser from `espree` to  `@babel/parser`.

Problems:
- `escope` does not recognize `ClassMethod` from `babel`. I'm not sure how to fix it. This must be done on `escope` side. 


I have verified that `acorn` and `espree` will trigger issue #352 , all other parsers are ok. But `esprima` is kind of dead. `Typescript` will run into the `escope` issue too. That's why I choose babel.

I started to want to patch recast by myself to fix the original issue. But maybe this PR is complete enough that you will have an interest in it. If you think this is not the direction to go, can close. 🙏 