### PR TITLE
Add support for JSX Fragments

### DIFF
--- a/src/traverser.js
+++ b/src/traverser.js
@@ -12,9 +12,12 @@ const jsxExtensionKeys = {
     JSXExpressionContainer: ['expression'],
     JSXOpeningElement: ['name', 'attributes'],
     JSXClosingElement: ['name'],
+    JSXOpeningFragment: [],
+    JSXClosingFragment: [],
     JSXAttribute: ['name', 'value'],
     JSXSpreadAttribute: ['argument'],
     JSXElement: ['openingElement', 'closingElement', 'children'],
+    JSXFragment: ['openingFragment', 'closingFragment', 'children'],
     JSXText: [],
   }
 };

--- a/test/transform/jsxTest.js
+++ b/test/transform/jsxTest.js
@@ -83,4 +83,12 @@ describe('JSX support', () => {
       'const foo = <div> {/* some comments */} </div>;'
     );
   });
+
+  it('should support JSX fragments', () => {
+    expectTransform(
+      'var foo = <>{a}</>;'
+    ).toReturn(
+      'const foo = <>{a}</>;'
+    );
+  });
 });


### PR DESCRIPTION
I have a file that uses <>...</> JSX Fragment syntax, and lebab errors on it:

```
Error: Unknown node type JSXFragment.
    at Controller.replace (/path/to/.npm/_npx/f7eb23749117ddf8/node_modules/estraverse/estraverse.js:632:27)
    at Object.replace (/path/to/.npm/_npx/f7eb23749117ddf8/node_modules/estraverse/estraverse.js:675:27)
    at Object.replace (/path/to/.npm/_npx/f7eb23749117ddf8/node_modules/lebab/lib/traverser.js:52:35)
    at _default (/path/to/.npm/_npx/f7eb23749117ddf8/node_modules/lebab/lib/transform/commonjs/importCommonjs.js:17:25)
    at _default (/path/to/.npm/_npx/f7eb23749117ddf8/node_modules/lebab/lib/transform/commonjs/index.js:11:34)
    at /path/to/.npm/_npx/f7eb23749117ddf8/node_modules/lebab/lib/Transformer.js:60:11
    at Array.forEach (<anonymous>)
    at /path/to/.npm/_npx/f7eb23749117ddf8/node_modules/lebab/lib/Transformer.js:59:26
    at Transformer.ignoringHashBangComment (/path/to/.npm/_npx/f7eb23749117ddf8/node_modules/lebab/lib/Transformer.js:79:25)
    at Transformer.applyAllTransforms (/path/to/.npm/_npx/f7eb23749117ddf8/node_modules/lebab/lib/Transformer.js:55:19)
```

To fix this I think we need to add some details to our traverser.

Fixes #362