### PR TITLE
Add support for `defineProperties` and static class properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ or they have significant bugs which can result in breaking your code.
     - [x] recognizes `Foo.prototype = { ...methods... };`
     - [x] recognizes static methods like `Foo.method = function(){ ... };`
     - [x] recognizes getters/setters defined with `Object.defineProperty()`
+    - [x] recognizes getters/setters defined with `Object.defineProperties()`
     - [x] recognizes inheritance with `Child.prototype = new Parent()`
     - [x] recognizes inheritance with `util.inherits(Child, Parent);`
     - [x] converts superclass constructor calls to `super()`

--- a/src/transform/class/PotentialMethod.js
+++ b/src/transform/class/PotentialMethod.js
@@ -16,8 +16,8 @@ class PotentialMethod {
    *   @param {Object} cfg.fullNode Node to remove after converting to class
    *   @param {Object[]} cfg.commentNodes Nodes to extract comments from
    *   @param {Object} cfg.parent
-   *   @param {String} cfg.kind Either 'get' or 'set' (optional)
-   *   @param {Boolean} cfg.static True to make static method (optional)
+   *   @param {String} [cfg.kind] Either 'get' or 'set' (optional)
+   *   @param {Boolean} [cfg.static] True to make static method (optional)
    */
   constructor(cfg) {
     this.name = cfg.name;

--- a/src/transform/class/matchObjectDefinePropertiesCall.js
+++ b/src/transform/class/matchObjectDefinePropertiesCall.js
@@ -1,0 +1,134 @@
+import {matches, extractAny} from 'f-matches';
+import {isAccessorDescriptor} from './matchObjectDefinePropertyCall.js';
+
+const matchObjectDefinePropertiesCallOnPrototype = matches({
+  type: 'ExpressionStatement',
+  expression: {
+    type: 'CallExpression',
+    callee: {
+      type: 'MemberExpression',
+      computed: false,
+      object: {
+        type: 'Identifier',
+        name: 'Object'
+      },
+      property: {
+        type: 'Identifier',
+        name: 'defineProperties'
+      }
+    },
+    arguments: [
+      {
+        type: 'MemberExpression',
+        computed: false,
+        object: {
+          type: 'Identifier',
+          name: extractAny('className')
+        },
+        property: {
+          type: 'Identifier',
+          name: 'prototype'
+        }
+      },
+      {
+        type: 'ObjectExpression',
+        properties: extractAny('methods')
+      }
+    ]
+  }
+});
+
+const matchObjectDefinePropertiesCall = matches({
+  type: 'ExpressionStatement',
+  expression: {
+    type: 'CallExpression',
+    callee: {
+      type: 'MemberExpression',
+      computed: false,
+      object: {
+        type: 'Identifier',
+        name: 'Object'
+      },
+      property: {
+        type: 'Identifier',
+        name: 'defineProperties'
+      }
+    },
+    arguments: [
+      {
+        type: 'Identifier',
+        name: extractAny('className')
+      },
+      {
+        type: 'ObjectExpression',
+        properties: extractAny('methods')
+      }
+    ]
+  }
+});
+
+export const matchDefinedProperties = matches({
+  type: 'Property',
+  key: {
+    type: 'Identifier',
+    name: extractAny('methodName')
+  },
+  computed: false,
+  value: {
+    type: 'ObjectExpression',
+    properties: extractAny('properties')
+  }
+});
+
+
+/**
+ * Matches: Object.defineProperties(<className>.prototype, {
+ *              <methodName>: {
+ *                <kind>: <methodNode>,
+ *              }
+ *              ...
+ *          })
+ *
+ * When node matches returns an array of objects with the extracted fields for each method:
+ *
+ * [{
+ *   - className
+ *   - methodName
+ *   - descriptors:
+ *       - propertyNode
+ *       - methodNode
+ *       - kind
+ * }]
+ *
+ * @param  {Object} node
+ * @return {Object[] | undefined}
+ */
+export default function(node) {
+  let {className, methods} = matchObjectDefinePropertiesCallOnPrototype(node);
+
+  let isStatic = false;
+  if (!className) {
+    ({className, methods} = matchObjectDefinePropertiesCall(node));
+    isStatic = true;
+  }
+
+  if (className) {
+    return methods.map(methodNode => {
+      const {methodName, properties} = matchDefinedProperties(methodNode);
+
+      return {
+        className: className,
+        methodName: methodName,
+        methodNode: methodNode,
+        descriptors: properties.filter(isAccessorDescriptor).map(prop => {
+          return {
+            propertyNode: prop,
+            methodNode: prop.value,
+            kind: prop.key.name,
+          };
+        }),
+        static: isStatic
+      };
+    });
+  }
+}

--- a/src/utils/multiReplaceStatement.js
+++ b/src/utils/multiReplaceStatement.js
@@ -34,6 +34,8 @@ function getBody(node) {
     return node.body;
   case 'SwitchCase':
     return node.consequent;
+  case 'ObjectExpression':
+    return node.properties;
   default:
     throw `Unsupported node type '${node.type}' in multiReplaceStatement()`;
   }


### PR DESCRIPTION
This library already supported `defineProperty` and this PR expands that to include `defineProperties`. This is the core request of https://github.com/lebab/lebab/issues/267

`defineProperty` only supported getters and setters and the same is true for `defineProperties`. It could be good to add support for class fields at some point but I focused only on matching the support `defineProperty` already had (and is probably enough for our usecase)

While I was in that code I also expanded support for both `defineProperty` _and_ `defineProperties` to support `static` methods detected based on whether the first argument is `MyClass.prototype` or just `MyClass` as is done in the other class matchers.

For context I've been looking into upgrading a very large library with many prototypal classes to newer ES6 `class` syntax and the more we can automate that process the better/faster it will go. This tool seemed like it could do but we _require_ support for `defineProperties` as most, if not all, our classes use that.